### PR TITLE
fix the type string errors

### DIFF
--- a/pkg/cmd/delete/token/cmd.go
+++ b/pkg/cmd/delete/token/cmd.go
@@ -22,7 +22,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 
 	cmd := &cobra.Command{
 		Use:          "token",
-		Short:        "delete the bootsrap token",
+		Short:        "delete the bootstrap token",
 		Example:      fmt.Sprintf(example, helpers.GetExampleHeader()),
 		SilenceUsage: true,
 		PreRun: func(c *cobra.Command, args []string) {

--- a/pkg/cmd/get/token/cmd.go
+++ b/pkg/cmd/get/token/cmd.go
@@ -22,7 +22,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 
 	cmd := &cobra.Command{
 		Use:          "token",
-		Short:        "get the bootsrap token",
+		Short:        "get the bootstrap token",
 		Example:      fmt.Sprintf(example, helpers.GetExampleHeader()),
 		SilenceUsage: true,
 		PreRun: func(c *cobra.Command, args []string) {


### PR DESCRIPTION
Signed-off-by: Leilei Hu <leileihu@cn.ibm.com>

Fix the type string `bootstrap` error in the `clusteradm get and delete --help`, Thanks 