### PR TITLE
There is no need to re-create the kubeClient inside the function approveCSR

### DIFF
--- a/pkg/cmd/accept/exec.go
+++ b/pkg/cmd/accept/exec.go
@@ -167,10 +167,6 @@ func (o *Options) approveCSR(kubeClient *kubernetes.Clientset, clusterName strin
 		LastUpdateTime: metav1.Now(),
 	})
 
-	kubeClient, err = o.ClusteradmFlags.KubectlFactory.KubernetesClientSet()
-	if err != nil {
-		return false, err
-	}
 	signingRequest := kubeClient.CertificatesV1().CertificateSigningRequests()
 	if _, err := signingRequest.UpdateApproval(context.TODO(), csr.Name, csr, metav1.UpdateOptions{}); err != nil {
 		return false, err


### PR DESCRIPTION
Signed-off-by: kim-fitness <jianjin@cn.ibm.com>

The `kubeClient` here is an input parameter of function `approveCSR`, so no need to re-create again inside the function.

I have done following UT case after remove those lines of code, case passed.
```
1. clusteradm join --hub-token xxx --hub-apiserver https://127.0.0.1:55091 --cluster-name kind-mc2
2. Wait the klusterlet was created on cluster kind-mc2
3. Switch to hub cluster
4. clusteradm accept --clusters kind-mc2 //The cluster kind-mc2 was accepted successfully
5. Check manaegedcluster from hub cluster, kind-mc2 was listed.
```