### PR TITLE
use Create file instead of OpenFile

### DIFF
--- a/pkg/helpers/apply/apply.go
+++ b/pkg/helpers/apply/apply.go
@@ -394,7 +394,7 @@ func WriteOutput(fileName string, output []string) (err error) {
 	if fileName == "" {
 		return nil
 	}
-	f, err := os.OpenFile(filepath.Clean(fileName), os.O_WRONLY|os.O_CREATE, 0600)
+	f, err := os.Create(filepath.Clean(fileName))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
with os.Openfile as it doesn't trunc, the output-file was mess up when overwritting an existing file
Signed-off-by: Dominique Vernier <dvernier@redhat.com>