### PR TITLE
Enhance output of accept subcommand to provide URLs for next steps. Fixed docs regarding addon enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ Accept the CSRs on the hub to approve the spoke clusters to join the hub.
 
 Install specific built-in add-on(s) to the hub cluster.
 
-`clusteradm install addons --names application-manager`
+`clusteradm install addon --names application-manager`
 
 ### enable addons
 
 Enable specific add-on(s) agent deployment to the given managed clusters of the specify namespace
 
-`clusteradm enable addons --names application-manager --ns namespace --clusters <cluster1>, <cluster2>,....`
+`clusteradm addon enable --names application-manager --namespace <namespace> --cluster <cluster1>,<cluster2>,....`

--- a/pkg/cmd/accept/exec.go
+++ b/pkg/cmd/accept/exec.go
@@ -99,6 +99,7 @@ func (o *Options) accept(kubeClient *kubernetes.Clientset, clusterClient *cluste
 		return false, err
 	}
 	if csrApproved && mcUpdated {
+		fmt.Printf("\n Your managed cluster %s has joined the Hub successfully. Visit https://open-cluster-management.io/scenarios or https://github.com/open-cluster-management-io/OCM/tree/main/solutions for next steps.\n", clusterName)
 		return true, nil
 	}
 	return false, nil

--- a/pkg/cmd/addon/enable/cmd.go
+++ b/pkg/cmd/addon/enable/cmd.go
@@ -13,7 +13,7 @@ import (
 
 var example = `
 # Enable addon on a cluster in speccified a namespace
-%[1]s addon enable --name application-manager --ns namespace --cluster cluster1,cluster2
+%[1]s addon enable --name application-manager --namespace namespace --cluster cluster1,cluster2
 `
 
 // NewCmd...


### PR DESCRIPTION
- Based on community feedback, enhanced the output of clusteradm accept command
- Fixed docs regarding addon enable. The short form of --namespace is -n (not -ns) Using long form for consistency with other params.

Signed-off-by: Mike Ng <ming@redhat.com>