### PR TITLE
Bugfix: Registration-operator CRD upgrade

### DIFF
--- a/pkg/cmd/init/scenario/init/clustermanagers.crd.yaml
+++ b/pkg/cmd/init/scenario/init/clustermanagers.crd.yaml
@@ -10,143 +10,190 @@ spec:
     listKind: ClusterManagerList
     plural: clustermanagers
     singular: clustermanager
-  preserveUnknownFields: false
   scope: Cluster
+  preserveUnknownFields: false
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: ClusterManager configures the controllers on the hub that govern registration and work distribution for attached Klusterlets. ClusterManager will only be deployed in open-cluster-management-hub namespace.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec represents a desired deployment configuration of controllers that govern registration and work distribution for attached Klusterlets.
-            properties:
-              placementImagePullSpec:
-                default: quay.io/open-cluster-management/placement
-                description: PlacementImagePullSpec represents the desired image configuration of placement controller/webhook installed on hub.
-                type: string
-              registrationImagePullSpec:
-                default: quay.io/open-cluster-management/registration
-                description: RegistrationImagePullSpec represents the desired image of registration controller/webhook installed on hub.
-                type: string
-              workImagePullSpec:
-                default: quay.io/open-cluster-management/work
-                description: WorkImagePullSpec represents the desired image configuration of work controller/webhook installed on hub.
-                type: string
-            type: object
-          status:
-            description: Status represents the current status of controllers that govern the lifecycle of managed clusters.
-            properties:
-              conditions:
-                description: 'Conditions contain the different condition statuses for this ClusterManager. Valid condition types are: Applied: Components in hub are applied. Available: Components in hub are available and ready to serve. Progressing: Components in hub are in a transitioning state. Degraded: Components in hub do not match the desired configuration and only provide degraded service.'
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterManager configures the controllers on the hub that govern registration and work distribution for attached Klusterlets. In Default mode, ClusterManager will only be deployed in open-cluster-management-hub namespace. In Detached mode, ClusterManager will be deployed in the namespace with the same name as cluster manager.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec represents a desired deployment configuration of controllers that govern registration and work distribution for attached Klusterlets.
+              type: object
+              properties:
+                deployOption:
+                  description: DeployOption contains the options of deploying a cluster-manager Default mode is used if DeployOption is not set.
+                  type: object
+                  default:
+                    mode: Default
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              generations:
-                description: Generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-                items:
-                  description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
+                    - mode
                   properties:
-                    group:
-                      description: group is the group of the resource that you're tracking
+                    mode:
+                      description: "Mode can be Default or Detached. For cluster-manager:   - In Default mode, the Hub is installed as a whole and all parts of Hub are deployed in the same cluster.   - In Detached mode, only crd and configurations are installed on one cluster(defined as hub-cluster). Controllers run in another cluster (defined as management-cluster) and connect to the hub with the kubeconfig in secret of \"external-hub-kubeconfig\"(a kubeconfig of hub-cluster with cluster-admin permission). For klusterlet:   - In Default mode, all klusterlet related resources are deployed on the managed cluster.   - In Detached mode, only crd and configurations are installed on the spoke/managed cluster. Controllers run in another cluster (defined as management-cluster) and connect to the mangaged cluster with the kubeconfig in secret of \"external-managed-kubeconfig\"(a kubeconfig of managed-cluster with cluster-admin permission). The purpose of Detached mode is to give it more flexibility, for example we can install a hub on a cluster with no worker nodes, meanwhile running all deployments on another more powerful cluster. And we can also register a managed cluster to the hub that has some firewall rules preventing access from the managed cluster. \n Note: Do not modify the Mode field once it's applied."
                       type: string
-                    lastGeneration:
-                      description: lastGeneration is the last generation of the resource that controller applies
-                      format: int64
-                      type: integer
-                    name:
-                      description: name is the name of the resource that you're tracking
-                      type: string
-                    namespace:
-                      description: namespace is where the resource that you're tracking is
-                      type: string
-                    resource:
-                      description: resource is the resource type of the resource that you're tracking
-                      type: string
-                    version:
-                      description: version is the version of the resource that you're tracking
-                      type: string
+                      default: Default
+                      enum:
+                        - Default
+                        - Detached
+                nodePlacement:
+                  description: NodePlacement enables explicit control over the scheduling of the deployed pods.
                   type: object
-                type: array
-              observedGeneration:
-                description: ObservedGeneration is the last generation change you've dealt with
-                format: int64
-                type: integer
-              relatedResources:
-                description: RelatedResources are used to track the resources that are related to this ClusterManager.
-                items:
-                  description: RelatedResourceMeta represents the resource that is managed by an operator
                   properties:
-                    group:
-                      description: group is the group of the resource that you're tracking
-                      type: string
-                    name:
-                      description: name is the name of the resource that you're tracking
-                      type: string
-                    namespace:
-                      description: namespace is where the thing you're tracking is
-                      type: string
-                    resource:
-                      description: resource is the resource type of the resource that you're tracking
-                      type: string
-                    version:
-                      description: version is the version of the thing you're tracking
-                      type: string
-                  type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    nodeSelector:
+                      description: NodeSelector defines which Nodes the Pods are scheduled on. The default is an empty list.
+                      type: object
+                      additionalProperties:
+                        type: string
+                    tolerations:
+                      description: Tolerations is attached by pods to tolerate any taint that matches the triple <key,value,effect> using the matching operator <operator>. The default is an empty list.
+                      type: array
+                      items:
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        type: object
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            type: integer
+                            format: int64
+                          value:
+                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                placementImagePullSpec:
+                  description: PlacementImagePullSpec represents the desired image configuration of placement controller/webhook installed on hub.
+                  type: string
+                  default: quay.io/open-cluster-management/placement
+                registrationImagePullSpec:
+                  description: RegistrationImagePullSpec represents the desired image of registration controller/webhook installed on hub.
+                  type: string
+                  default: quay.io/open-cluster-management/registration
+                workImagePullSpec:
+                  description: WorkImagePullSpec represents the desired image configuration of work controller/webhook installed on hub.
+                  type: string
+                  default: quay.io/open-cluster-management/work
+            status:
+              description: Status represents the current status of controllers that govern the lifecycle of managed clusters.
+              type: object
+              properties:
+                conditions:
+                  description: 'Conditions contain the different condition statuses for this ClusterManager. Valid condition types are: Applied: Components in hub are applied. Available: Components in hub are available and ready to serve. Progressing: Components in hub are in a transitioning state. Degraded: Components in hub do not match the desired configuration and only provide degraded service.'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                generations:
+                  description: Generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
+                  type: array
+                  items:
+                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
+                    type: object
+                    properties:
+                      group:
+                        description: group is the group of the resource that you're tracking
+                        type: string
+                      lastGeneration:
+                        description: lastGeneration is the last generation of the resource that controller applies
+                        type: integer
+                        format: int64
+                      name:
+                        description: name is the name of the resource that you're tracking
+                        type: string
+                      namespace:
+                        description: namespace is where the resource that you're tracking is
+                        type: string
+                      resource:
+                        description: resource is the resource type of the resource that you're tracking
+                        type: string
+                      version:
+                        description: version is the version of the resource that you're tracking
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last generation change you've dealt with
+                  type: integer
+                  format: int64
+                relatedResources:
+                  description: RelatedResources are used to track the resources that are related to this ClusterManager.
+                  type: array
+                  items:
+                    description: RelatedResourceMeta represents the resource that is managed by an operator
+                    type: object
+                    properties:
+                      group:
+                        description: group is the group of the resource that you're tracking
+                        type: string
+                      name:
+                        description: name is the name of the resource that you're tracking
+                        type: string
+                      namespace:
+                        description: namespace is where the thing you're tracking is
+                        type: string
+                      resource:
+                        description: resource is the resource type of the resource that you're tracking
+                        type: string
+                      version:
+                        description: version is the version of the thing you're tracking
+                        type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/cmd/join/scenario/join/klusterlets.crd.yaml
+++ b/pkg/cmd/join/scenario/join/klusterlets.crd.yaml
@@ -13,221 +13,203 @@ spec:
   scope: Cluster
   preserveUnknownFields: false
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: Klusterlet represents controllers on the managed cluster. When
-          configured, the Klusterlet requires a secret named of bootstrap-hub-kubeconfig
-          in the same namespace to allow API requests to the hub for the registration
-          protocol.
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec represents the desired deployment configuration of Klusterlet
-              agent.
-            type: object
-            properties:
-              clusterName:
-                description: ClusterName is the name of the managed cluster to be
-                  created on hub. The Klusterlet agent generates a random name if
-                  it is not set, or discovers the appropriate cluster name on OpenShift.
-                type: string
-              externalServerURLs:
-                description: ExternalServerURLs represents the a list of apiserver
-                  urls and ca bundles that is accessible externally If it is set empty,
-                  managed cluster has no externally accessible url that hub cluster
-                  can visit.
-                type: array
-                items:
-                  description: ServerURL represents the apiserver url and ca bundle
-                    that is accessible externally
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Klusterlet represents controllers to install the resources for a managed cluster. When configured, the Klusterlet requires a secret named bootstrap-hub-kubeconfig in the agent namespace to allow API requests to the hub for the registration protocol. In Detached mode, the Klusterlet requires an additional secret named external-managed-kubeconfig in the agent namespace to allow API requests to the managed cluster for resources installation.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec represents the desired deployment configuration of Klusterlet agent.
+              type: object
+              properties:
+                clusterName:
+                  description: ClusterName is the name of the managed cluster to be created on hub. The Klusterlet agent generates a random name if it is not set, or discovers the appropriate cluster name on OpenShift.
+                  type: string
+                deployOption:
+                  description: DeployOption contains the options of deploying a klusterlet
                   type: object
-                  properties:
-                    caBundle:
-                      description: CABundle is the ca bundle to connect to apiserver
-                        of the managed cluster. System certs are used if it is not
-                        set.
-                      type: string
-                      format: byte
-                    url:
-                      description: URL is the url of apiserver endpoint of the managed
-                        cluster.
-                      type: string
-              namespace:
-                description: Namespace is the namespace to deploy the agent. The namespace
-                  must have a prefix of "open-cluster-management-", and if it is not
-                  set, the namespace of "open-cluster-management-agent" is used to
-                  deploy agent.
-                type: string
-              registrationImagePullSpec:
-                description: RegistrationImagePullSpec represents the desired image
-                  configuration of registration agent.
-                type: string
-              workImagePullSpec:
-                description: WorkImagePullSpec represents the desired image configuration
-                  of work agent.
-                type: string
-          status:
-            description: Status represents the current status of Klusterlet agent.
-            type: object
-            properties:
-              conditions:
-                description: 'Conditions contain the different condition statuses
-                  for this Klusterlet. Valid condition types are: Applied: Components
-                  have been applied in the managed cluster. Available: Components
-                  in the managed cluster are available and ready to serve. Progressing:
-                  Components in the managed cluster are in a transitioning state.
-                  Degraded: Components in the managed cluster do not match the desired
-                  configuration and only provide degraded service.'
-                type: array
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
-                  type: object
+                  default:
+                    mode: Default
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - mode
                   properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                    mode:
+                      description: "Mode can be Default or Detached. For cluster-manager:   - In Default mode, the Hub is installed as a whole and all parts of Hub are deployed in the same cluster.   - In Detached mode, only crd and configurations are installed on one cluster(defined as hub-cluster). Controllers run in another cluster (defined as management-cluster) and connect to the hub with the kubeconfig in secret of \"external-hub-kubeconfig\"(a kubeconfig of hub-cluster with cluster-admin permission). For klusterlet:   - In Default mode, all klusterlet related resources are deployed on the managed cluster.   - In Detached mode, only crd and configurations are installed on the spoke/managed cluster. Controllers run in another cluster (defined as management-cluster) and connect to the mangaged cluster with the kubeconfig in secret of \"external-managed-kubeconfig\"(a kubeconfig of managed-cluster with cluster-admin permission). The purpose of Detached mode is to give it more flexibility, for example we can install a hub on a cluster with no worker nodes, meanwhile running all deployments on another more powerful cluster. And we can also register a managed cluster to the hub that has some firewall rules preventing access from the managed cluster. \n Note: Do not modify the Mode field once it's applied."
                       type: string
-                      format: date-time
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      type: string
-                      maxLength: 32768
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      type: integer
-                      format: int64
-                      minimum: 0
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      type: string
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      type: string
+                      default: Default
                       enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      type: string
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-              generations:
-                description: Generations are used to determine when an item needs
-                  to be reconciled or has changed in a way that needs a reaction.
-                type: array
-                items:
-                  description: GenerationStatus keeps track of the generation for
-                    a given resource so that decisions about forced updates can be
-                    made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
+                        - Default
+                        - Detached
+                externalServerURLs:
+                  description: ExternalServerURLs represents the a list of apiserver urls and ca bundles that is accessible externally If it is set empty, managed cluster has no externally accessible url that hub cluster can visit.
+                  type: array
+                  items:
+                    description: ServerURL represents the apiserver url and ca bundle that is accessible externally
+                    type: object
+                    properties:
+                      caBundle:
+                        description: CABundle is the ca bundle to connect to apiserver of the managed cluster. System certs are used if it is not set.
+                        type: string
+                        format: byte
+                      url:
+                        description: URL is the url of apiserver endpoint of the managed cluster.
+                        type: string
+                namespace:
+                  description: 'Namespace is the namespace to deploy the agent. The namespace must have a prefix of "open-cluster-management-", and if it is not set, the namespace of "open-cluster-management-agent" is used to deploy agent. Note: in Detach mode, this field will be **ignored**, the agent will be deployed to the namespace with the same name as klusterlet.'
+                  type: string
+                nodePlacement:
+                  description: NodePlacement enables explicit control over the scheduling of the deployed pods.
                   type: object
                   properties:
-                    group:
-                      description: group is the group of the resource that you're
-                        tracking
-                      type: string
-                    lastGeneration:
-                      description: lastGeneration is the last generation of the resource
-                        that controller applies
-                      type: integer
-                      format: int64
-                    name:
-                      description: name is the name of the resource that you're tracking
-                      type: string
-                    namespace:
-                      description: namespace is where the resource that you're tracking
-                        is
-                      type: string
-                    resource:
-                      description: resource is the resource type of the resource that
-                        you're tracking
-                      type: string
-                    version:
-                      description: version is the version of the resource that you're
-                        tracking
-                      type: string
-              observedGeneration:
-                description: ObservedGeneration is the last generation change you've
-                  dealt with
-                type: integer
-                format: int64
-              relatedResources:
-                description: RelatedResources are used to track the resources that
-                  are related to this Klusterlet.
-                type: array
-                items:
-                  description: RelatedResourceMeta represents the resource that is
-                    managed by an operator
-                  type: object
-                  properties:
-                    group:
-                      description: group is the group of the resource that you're
-                        tracking
-                      type: string
-                    name:
-                      description: name is the name of the resource that you're tracking
-                      type: string
-                    namespace:
-                      description: namespace is where the thing you're tracking is
-                      type: string
-                    resource:
-                      description: resource is the resource type of the resource that
-                        you're tracking
-                      type: string
-                    version:
-                      description: version is the version of the thing you're tracking
-                      type: string
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    nodeSelector:
+                      description: NodeSelector defines which Nodes the Pods are scheduled on. The default is an empty list.
+                      type: object
+                      additionalProperties:
+                        type: string
+                    tolerations:
+                      description: Tolerations is attached by pods to tolerate any taint that matches the triple <key,value,effect> using the matching operator <operator>. The default is an empty list.
+                      type: array
+                      items:
+                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                        type: object
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                            type: integer
+                            format: int64
+                          value:
+                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                registrationImagePullSpec:
+                  description: RegistrationImagePullSpec represents the desired image configuration of registration agent.
+                  type: string
+                  default: quay.io/open-cluster-management/registration
+                workImagePullSpec:
+                  description: WorkImagePullSpec represents the desired image configuration of work agent.
+                  type: string
+                  default: quay.io/open-cluster-management/work
+            status:
+              description: Status represents the current status of Klusterlet agent.
+              type: object
+              properties:
+                conditions:
+                  description: 'Conditions contain the different condition statuses for this Klusterlet. Valid condition types are: Applied: Components have been applied in the managed cluster. Available: Components in the managed cluster are available and ready to serve. Progressing: Components in the managed cluster are in a transitioning state. Degraded: Components in the managed cluster do not match the desired configuration and only provide degraded service.'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                generations:
+                  description: Generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
+                  type: array
+                  items:
+                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made. The definition matches the GenerationStatus defined in github.com/openshift/api/v1
+                    type: object
+                    properties:
+                      group:
+                        description: group is the group of the resource that you're tracking
+                        type: string
+                      lastGeneration:
+                        description: lastGeneration is the last generation of the resource that controller applies
+                        type: integer
+                        format: int64
+                      name:
+                        description: name is the name of the resource that you're tracking
+                        type: string
+                      namespace:
+                        description: namespace is where the resource that you're tracking is
+                        type: string
+                      resource:
+                        description: resource is the resource type of the resource that you're tracking
+                        type: string
+                      version:
+                        description: version is the version of the resource that you're tracking
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last generation change you've dealt with
+                  type: integer
+                  format: int64
+                relatedResources:
+                  description: RelatedResources are used to track the resources that are related to this Klusterlet.
+                  type: array
+                  items:
+                    description: RelatedResourceMeta represents the resource that is managed by an operator
+                    type: object
+                    properties:
+                      group:
+                        description: group is the group of the resource that you're tracking
+                        type: string
+                      name:
+                        description: name is the name of the resource that you're tracking
+                        type: string
+                      namespace:
+                        description: namespace is where the thing you're tracking is
+                        type: string
+                      resource:
+                        description: resource is the resource type of the resource that you're tracking
+                        type: string
+                      version:
+                        description: version is the version of the thing you're tracking
+                        type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
the embeded CRD from clusteradm at `v0.1.0` release is not aligned w/ `v0.6.0` registration-operator, so after upgrading the operator image to v0.6.0 the CRD will stay at `v0.5.0` release which causes the following errors:

```
E0214 20:57:40.543624       1 base_controller.go:251] "CRDMigrationController" controller failed to sync "cluster-manager", err: unsupport install mode: 
E0214 21:01:38.040060       1 base_controller.go:251] "CRDMigrationController" controller failed to sync "cluster-manager", err: unsupport install mode: 
I0214 21:01:38.040085       1 certrotation_controller.go:157] Reconciling ClusterManager "cluster-manager"
I0214 21:01:38.040060       1 clustermanager_status_controller.go:62] Reconciling ClusterManager "cluster-manager"
I0214 21:01:38.120645       1 certrotation_controller.go:157] Reconciling ClusterManager "cluster-manager"
```

/cc @qiujian16