### PR TITLE
Remove deploy-agent option from subscription controller

### DIFF
--- a/pkg/cmd/install/addons/scenario/addon/appmgr/deployment_subscription.yaml
+++ b/pkg/cmd/install/addons/scenario/addon/appmgr/deployment_subscription.yaml
@@ -25,7 +25,6 @@ spec:
           command:
           - /usr/local/bin/multicluster-operators-subscription
           - --sync-interval=60
-          - --deploy-agent
           - --agent-image=quay.io/open-cluster-management/multicloud-operators-subscription:latest
           imagePullPolicy: IfNotPresent
           env:


### PR DESCRIPTION
The deploy-agent option was removed from the subscription controller.

https://github.com/open-cluster-management-io/multicloud-operators-subscription/issues/106

Signed-off-by: Philip Wu <phwu@redhat.com>