### PR TITLE
Add policy-framework to hub-addon install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ clusteradm <cmd> [subcmd] [flags]
 
 ## Client
 
-- The [main](cmd/clusteradm.go) provides a cmdutil.Factory which can be laverage to get different clients and also the *rest.Config. The factory can be passed to the cobra.Command and then save in the Options.
+- The [main](cmd/clusteradm.go) provides a cmdutil.Factory which can be leveraged to get different clients and also the *rest.Config. The factory can be passed to the cobra.Command and then save in the Options.
 
 ```Go
 	kubeClient, err := o.factory.KubernetesClientSet()

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Install specific built-in add-on(s) to the hub cluster.
 
 `clusteradm install hub-addon --names application-manager`
 
+`clusteradm install hub-addon --names policy-framework`
+
 ### enable addons
 
 Enable specific add-on(s) agent deployment to the given managed clusters of the specify namespace

--- a/build/check-copyright.sh
+++ b/build/check-copyright.sh
@@ -72,9 +72,9 @@ do
 
         COMMUNITY_HEADER_AS_COMMENT="$COMMENT_START$COMMUNITY_COPY_HEADER_STRING$COMMENT_END"
 
-        if ! grep -q "$COMMUNITY_HEADER_AS_COMMENT" "$FILE"; then
+        if [ -f "$FILE" ] && ! grep -q "$COMMUNITY_HEADER_AS_COMMENT" "$FILE"; then
             echo "FILE: $FILE:"
-            echo -e "\t- Need add Community copyright header to file"
+            echo -e "\t- Need to add Community copyright header to file"
             ERROR=true
         fi
     fi

--- a/pkg/cmd/install/hubaddon/cmd.go
+++ b/pkg/cmd/install/hubaddon/cmd.go
@@ -14,6 +14,7 @@ import (
 var example = `
 # Install built-in add-ons to the hub cluster
 %[1]s install hub-addon --names application-manager
+%[1]s install hub-addon --names policy-framework
 `
 
 // NewCmd...
@@ -21,7 +22,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	o := newOptions(clusteradmFlags, streams)
 
 	cmd := &cobra.Command{
-		Use:          "addon",
+		Use:          "hub-addon",
 		Short:        "install hub-addon",
 		Long:         "Install specific built-in add-on(s) to the hub cluster",
 		Example:      fmt.Sprintf(example, clusteradmhelpers.GetExampleHeader()),
@@ -46,7 +47,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 		},
 	}
 
-	cmd.Flags().StringVar(&o.names, "names", "", "Names of the built-in add-on to install (comma separated). The built-in add-ons are: application-manager")
+	cmd.Flags().StringVar(&o.names, "names", "", "Names of the built-in add-on to install (comma separated). The built-in add-ons are: application-manager, policy-framework")
 	cmd.Flags().StringVar(&o.outputFile, "output-file", "", "The generated resources will be copied in the specified file")
 
 	return cmd

--- a/pkg/cmd/install/hubaddon/exec_test.go
+++ b/pkg/cmd/install/hubaddon/exec_test.go
@@ -14,6 +14,7 @@ const (
 	ocmNamespace           = "open-cluster-management"
 	channelDeployment      = "multicluster-operators-channel"
 	subscriptionDeployment = "multicluster-operators-subscription"
+	propagatorDeployment   = "governance-policy-propagator"
 )
 
 var _ = ginkgo.Describe("install hub-addon", func() {
@@ -80,6 +81,26 @@ var _ = ginkgo.Describe("install hub-addon", func() {
 				}
 				return nil
 			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("Should deploy the built-in policy-framework add-on deployments in open-cluster-management namespace successfully", func() {
+			o := Options{
+				values: Values{
+					hubAddons: []string{policyFrameworkAddonName},
+				},
+			}
+
+			err := o.runWithClient(kubeClient, apiExtensionsClient, dynamicClient, false)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			gomega.Eventually(func() error {
+				_, err := kubeClient.AppsV1().Deployments(ocmNamespace).Get(context.Background(), propagatorDeployment, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				return nil
+			}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
+
 		})
 	})
 })

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/policy.open-cluster-management.io_placementbindings.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/policy.open-cluster-management.io_placementbindings.yaml
@@ -1,0 +1,101 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: placementbindings.policy.open-cluster-management.io
+spec:
+  group: policy.open-cluster-management.io
+  names:
+    kind: PlacementBinding
+    listKind: PlacementBindingList
+    plural: placementbindings
+    shortNames:
+    - pb
+    singular: placementbinding
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: PlacementBinding is the Schema for the placementbindings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          placementRef:
+            description: PlacementSubject reference
+            properties:
+              apiGroup:
+                enum:
+                - apps.open-cluster-management.io
+                - cluster.open-cluster-management.io
+                minLength: 1
+                type: string
+              kind:
+                enum:
+                - PlacementRule
+                - Placement
+                minLength: 1
+                type: string
+              name:
+                minLength: 1
+                type: string
+            required:
+            - apiGroup
+            - kind
+            - name
+            type: object
+          status:
+            description: PlacementBindingStatus defines the observed state of PlacementBinding
+            type: object
+          subjects:
+            items:
+              description: Subject reference
+              properties:
+                apiGroup:
+                  enum:
+                  - policy.open-cluster-management.io
+                  minLength: 1
+                  type: string
+                kind:
+                  enum:
+                  - Policy
+                  - PolicySet
+                  minLength: 1
+                  type: string
+                name:
+                  minLength: 1
+                  type: string
+              required:
+              - apiGroup
+              - kind
+              - name
+              type: object
+            minItems: 1
+            type: array
+        required:
+        - placementRef
+        - subjects
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/policy.open-cluster-management.io_policies.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/policy.open-cluster-management.io_policies.yaml
@@ -1,0 +1,163 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: policies.policy.open-cluster-management.io
+spec:
+  group: policy.open-cluster-management.io
+  names:
+    kind: Policy
+    listKind: PolicyList
+    plural: policies
+    shortNames:
+    - plc
+    singular: policy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.remediationAction
+      name: Remediation action
+      type: string
+    - jsonPath: .status.compliant
+      name: Compliance state
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Policy is the Schema for the policies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicySpec defines the desired state of Policy
+            properties:
+              disabled:
+                type: boolean
+              policy-templates:
+                items:
+                  description: PolicyTemplate template for custom security policy
+                  properties:
+                    objectDefinition:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - objectDefinition
+                  type: object
+                type: array
+              remediationAction:
+                description: RemediationAction describes weather to enforce or inform
+                enum:
+                - Inform
+                - inform
+                - Enforce
+                - enforce
+                type: string
+            required:
+            - disabled
+            - policy-templates
+            type: object
+          status:
+            description: PolicyStatus defines the observed state of Policy
+            properties:
+              compliant:
+                description: ComplianceState shows the state of enforcement
+                enum:
+                - Compliant
+                - NonCompliant
+                type: string
+              details:
+                items:
+                  description: DetailsPerTemplate defines compliance details and history
+                  properties:
+                    compliant:
+                      description: ComplianceState shows the state of enforcement
+                      type: string
+                    history:
+                      items:
+                        description: ComplianceHistory defines compliance details
+                          history
+                        properties:
+                          eventName:
+                            type: string
+                          lastTimestamp:
+                            format: date-time
+                            type: string
+                          message:
+                            type: string
+                        type: object
+                      type: array
+                    templateMeta:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                type: array
+              placement:
+                items:
+                  description: Placement defines the placement results
+                  properties:
+                    decisions:
+                      items:
+                        description: PlacementDecision defines the decision made by
+                          controller
+                        properties:
+                          clusterName:
+                            type: string
+                          clusterNamespace:
+                            type: string
+                        type: object
+                      type: array
+                    placement:
+                      type: string
+                    placementBinding:
+                      type: string
+                    placementRule:
+                      type: string
+                    policySet:
+                      type: string
+                  type: object
+                type: array
+              status:
+                items:
+                  description: CompliancePerClusterStatus defines compliance per cluster
+                    status
+                  properties:
+                    clustername:
+                      type: string
+                    clusternamespace:
+                      type: string
+                    compliant:
+                      description: ComplianceState shows the state of enforcement
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/policy.open-cluster-management.io_policyautomations.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/policy.open-cluster-management.io_policyautomations.yaml
@@ -1,0 +1,100 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: policyautomations.policy.open-cluster-management.io
+spec:
+  group: policy.open-cluster-management.io
+  names:
+    kind: PolicyAutomation
+    listKind: PolicyAutomationList
+    plural: policyautomations
+    shortNames:
+    - plca
+    singular: policyautomation
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: PolicyAutomation is the Schema for the policyautomations API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyAutomationSpec defines the desired state of PolicyAutomation
+            properties:
+              automationDef:
+                description: AutomationDef defines the automation to invoke
+                properties:
+                  extra_vars:
+                    description: ExtraVars is passed to the Ansible job at execution
+                      time and is a known Ansible entity.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  name:
+                    description: Name of the Ansible Template to run in Tower as a
+                      job
+                    minLength: 1
+                    type: string
+                  secret:
+                    minLength: 1
+                    type: string
+                  type:
+                    description: Type of the automation to invoke
+                    type: string
+                required:
+                - name
+                - secret
+                type: object
+              eventHook:
+                description: EventHook decides when automation is going to be triggered
+                enum:
+                - noncompliant
+                type: string
+              mode:
+                description: Mode decides how automation is going to be triggered
+                enum:
+                - once
+                - disabled
+                type: string
+              policyRef:
+                description: PolicyRef is the name of the policy automation is going
+                  to binding with.
+                type: string
+              rescanAfter:
+                type: string
+            required:
+            - automationDef
+            - mode
+            - policyRef
+            type: object
+          status:
+            description: PolicyAutomationStatus defines the observed state of PolicyAutomation
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/policy.open-cluster-management.io_policysets.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/policy.open-cluster-management.io_policysets.yaml
@@ -1,0 +1,114 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: policysets.policy.open-cluster-management.io
+spec:
+  group: policy.open-cluster-management.io
+  names:
+    kind: PolicySet
+    listKind: PolicySetList
+    plural: policysets
+    shortNames:
+    - plcset
+    singular: policyset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.compliant
+      name: Compliance state
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: PolicySet is the Schema for the policysets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicySetSpec defines the desired state of PolicySet
+            properties:
+              description:
+                type: string
+              policies:
+                items:
+                  minLength: 1
+                  type: string
+                type: array
+            required:
+            - policies
+            type: object
+          status:
+            description: PolicySetStatus defines the observed state of PolicySet
+            properties:
+              compliant:
+                type: string
+              placement:
+                items:
+                  description: PolicySetStatusPlacement defines a placement object
+                    for the status
+                  properties:
+                    placement:
+                      type: string
+                    placementBinding:
+                      type: string
+                    placementRule:
+                      type: string
+                  type: object
+                type: array
+              results:
+                items:
+                  description: PolicySetStatusResult shows the compliance status of
+                    a policy in the set
+                  properties:
+                    clusters:
+                      items:
+                        description: PolicySetResultCluster shows the compliance status
+                          of a policy for a specific cluster
+                        properties:
+                          clusterName:
+                            type: string
+                          clusterNamespace:
+                            type: string
+                          compliant:
+                            type: string
+                        type: object
+                      type: array
+                    compliant:
+                      type: string
+                    message:
+                      type: string
+                    policy:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_clusterrole.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_clusterrole.yaml
@@ -1,0 +1,173 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: governance-policy-propagator
+rules:
+- apiGroups:
+  - apps.open-cluster-management.io
+  resources:
+  - placementrules
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  - placementdecisions
+  - placements
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - policy-encryption-key
+  resources:
+  - secrets
+  verbs:
+  - get
+  - update
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - placementbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policyautomations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policyautomations/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policyautomations/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policysets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policysets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policysets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - tower.ansible.com
+  resources:
+  - ansiblejobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_clusterrolebinding.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: governance-policy-propagator-global
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: governance-policy-propagator
+subjects:
+- kind: ServiceAccount
+  name: governance-policy-propagator
+  namespace: open-cluster-management

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_deployment.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_deployment.yaml
@@ -1,0 +1,40 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: governance-policy-propagator
+  namespace: open-cluster-management
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: governance-policy-propagator
+  template:
+    metadata:
+      labels:
+        name: governance-policy-propagator
+    spec:
+      containers:
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=:8383
+        - --leader-elect
+        command:
+        - governance-policy-propagator
+        env:
+        - name: WATCH_NAMESPACE
+          value: ""
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: governance-policy-propagator
+        image: quay.io/open-cluster-management/governance-policy-propagator:latest
+        imagePullPolicy: Always
+        name: governance-policy-propagator
+        ports:
+        - containerPort: 8383
+          name: http
+          protocol: TCP
+      serviceAccountName: governance-policy-propagator

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_role.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_role.yaml
@@ -1,0 +1,38 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: governance-policy-propagator-leader-election-role
+  namespace: open-cluster-management
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_rolebinding.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_rolebinding.yaml
@@ -1,0 +1,14 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: governance-policy-propagator-leader-election-rolebinding
+  namespace: open-cluster-management
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: governance-policy-propagator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: governance-policy-propagator
+  namespace: open-cluster-management

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_serviceaccount.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_serviceaccount.yaml
@@ -1,0 +1,6 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: governance-policy-propagator
+  namespace: open-cluster-management

--- a/pkg/helpers/apply/apply.go
+++ b/pkg/helpers/apply/apply.go
@@ -73,7 +73,7 @@ func (a *Applier) ApplyDeployment(
 	name string) (string, error) {
 	genericScheme.AddKnownTypes(appsv1.SchemeGroupVersion, &appsv1.Deployment{})
 	recorder := events.NewInMemoryRecorder(helpers.GetExampleHeader())
-	deploymentBytes, err := a.MustTempalteAsset(reader, values, headerFile, name)
+	deploymentBytes, err := a.MustTemplateAsset(reader, values, headerFile, name)
 	if err != nil {
 		return string(deploymentBytes), err
 	}
@@ -110,7 +110,7 @@ func (a *Applier) ApplyDirectly(
 	//Apply resources
 	clients := resourceapply.NewClientHolder().WithAPIExtensionsClient(a.apiExtensionsClient).WithDynamicClient(a.dynamicClient).WithKubernetes(a.kubeClient)
 	resourceResults := resourceapply.ApplyDirectly(context.TODO(), clients, recorder, func(name string) ([]byte, error) {
-		out, err := a.MustTempalteAsset(reader, values, headerFile, name)
+		out, err := a.MustTemplateAsset(reader, values, headerFile, name)
 		if err != nil {
 			return nil, err
 		}
@@ -161,7 +161,7 @@ func (a *Applier) ApplyCustomResource(
 	if a.dynamicClient == nil {
 		return output, fmt.Errorf("missing dynamicClient")
 	}
-	asset, err := a.MustTempalteAsset(reader, values, headerFile, name)
+	asset, err := a.MustTemplateAsset(reader, values, headerFile, name)
 	output = string(asset)
 	if err != nil {
 		return output, err
@@ -236,7 +236,7 @@ func getTemplate(templateName string, customFuncMap template.FuncMap) *template.
 func (a *Applier) MustTemplateAssets(reader asset.ScenarioReader, values interface{}, headerFile string, files ...string) ([]string, error) {
 	output := make([]string, 0)
 	for _, name := range files {
-		deploymentBytes, err := a.MustTempalteAsset(reader, values, headerFile, name)
+		deploymentBytes, err := a.MustTemplateAsset(reader, values, headerFile, name)
 		if err != nil {
 			if IsEmptyAsset(err) {
 				continue
@@ -248,12 +248,12 @@ func (a *Applier) MustTemplateAssets(reader asset.ScenarioReader, values interfa
 	return output, nil
 }
 
-//MustTempalteAsset generates textual output for a template file name.
+//MustTemplateAsset generates textual output for a template file name.
 //The headerfile will be added to each file.
 //Usually it contains nested template definitions as described https://golang.org/pkg/text/template/#hdr-Nested_template_definitions
 //This allows to add functions which can be use in each file.
 //The values object will be used to render the template
-func (a *Applier) MustTempalteAsset(reader asset.ScenarioReader, values interface{}, headerFile, name string) ([]byte, error) {
+func (a *Applier) MustTemplateAsset(reader asset.ScenarioReader, values interface{}, headerFile, name string) ([]byte, error) {
 	tmpl := getTemplate(name, a.templateFuncMap)
 	h := []byte{}
 	var err error

--- a/pkg/helpers/apply/apply_test.go
+++ b/pkg/helpers/apply/apply_test.go
@@ -9,7 +9,7 @@ import (
 	"open-cluster-management.io/clusteradm/test/unit/resources/scenario"
 )
 
-func TestMustTempalteAsset(t *testing.T) {
+func TestMustTemplateAsset(t *testing.T) {
 	type args struct {
 		name       string
 		headerFile string
@@ -79,13 +79,13 @@ func TestMustTempalteAsset(t *testing.T) {
 	a := ab.Build()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := a.MustTempalteAsset(tt.args.reader, tt.args.values, tt.args.headerFile, tt.args.name)
+			got, err := a.MustTemplateAsset(tt.args.reader, tt.args.values, tt.args.headerFile, tt.args.name)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("MustTempalteAsset() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("MustTemplateAsset() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("MustTempalteAsset() = \n<EOF>%v</EOF>\n, want \n<EOF>%v</EOF>", string(got), string(tt.want))
+				t.Errorf("MustTemplateAsset() = \n<EOF>%v</EOF>\n, want \n<EOF>%v</EOF>", string(got), string(tt.want))
 			}
 		})
 	}


### PR DESCRIPTION
Adds `clusteradm` command for `policy-framework`:

```bash
clusteradm install hub-addon --name policy-framework
```

I'm debating how these should be named and whether we should have different names between `clusteradm install hub-addon` and `clusteradm addon enable` or use 'policy-framework' for both core components (this would match app's current behaviors). The `config-policy-controller` could remain a separate name for `clusteradm addon enable` or we could roll it in...