### PR TITLE
Fix output format issue of join

### DIFF
--- a/pkg/cmd/join/exec.go
+++ b/pkg/cmd/join/exec.go
@@ -31,7 +31,7 @@ import (
 )
 
 func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
-	klog.V(1).InfoS("join options:", "dry-run", o.ClusteradmFlags.DryRun, "cluster", o.clusterName, "api-server", o.hubAPIServer, o.outputFile)
+	klog.V(1).InfoS("join options:", "dry-run", o.ClusteradmFlags.DryRun, "cluster", o.clusterName, "api-server", o.hubAPIServer, "output", o.outputFile)
 
 	o.values = Values{
 		ClusterName: o.clusterName,


### PR DESCRIPTION
The format of output is wrong:

```
"join options:" dry-run=true cluster="cluster1" api-server="https://127.0.0.1:35123" ="(MISSING)"
```

Signed-off-by: jichenjc <jichenjc@cn.ibm.com>