### PR TITLE
Add more log for showing the image version in join command

### DIFF
--- a/pkg/cmd/join/exec.go
+++ b/pkg/cmd/join/exec.go
@@ -53,6 +53,11 @@ func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
 		WorkImageVersion:         versionBundle.Work,
 		OperatorImageVersion:     versionBundle.Operator,
 	}
+	klog.V(3).InfoS("Image version:",
+		"'registration image version'", versionBundle.Registration,
+		"'placement image version'", versionBundle.Placement,
+		"'work image version'", versionBundle.Work,
+		"'operator image version'", versionBundle.Operator)
 
 	kubeClient, err := o.ClusteradmFlags.KubectlFactory.KubernetesClientSet()
 	if err != nil {


### PR DESCRIPTION
output looks like this 
```
I0325 10:10:25.105009  872082 exec.go:57] 'registration image version'="v0.6.0" 'placement image version'="v0.3.0" 'work image version'="v0.6.0" 'operator image version'="v0.6.0"
```

Signed-off-by: jichenjc <jichenjc@cn.ibm.com>