### PR TITLE
add change line to make output clear

### DIFF
--- a/pkg/cmd/upgrade/clustermanager/exec.go
+++ b/pkg/cmd/upgrade/clustermanager/exec.go
@@ -62,7 +62,7 @@ func (o *Options) validate() error {
 
 	//TODO check desired version is greater then current version 
 
-	fmt.Fprint(o.Streams.Out, "clustermanager installed. starting upgrade")
+	fmt.Fprint(o.Streams.Out, "clustermanager installed. starting upgrade\n")
 
 
 	return nil
@@ -126,7 +126,7 @@ func (o *Options) run() error {
 	output = append(output, out...)
 
 
-	fmt.Fprint(o.Streams.Out,"upgraded completed successfully")
+	fmt.Fprint(o.Streams.Out,"upgraded completed successfully\n")
 	return apply.WriteOutput("", output)
 }
 

--- a/pkg/cmd/upgrade/klusterlet/exec.go
+++ b/pkg/cmd/upgrade/klusterlet/exec.go
@@ -87,6 +87,7 @@ func (o *Options) validate() error {
 		return fmt.Errorf("klusterlet is not installed")
 	}
 	fmt.Fprint(o.Streams.Out, "Klusterlet installed. starting upgrade ")
+	fmt.Fprint(o.Streams.Out, "Klusterlet installed. starting upgrade\n")
 
 	return nil
 }
@@ -144,6 +145,7 @@ func (o *Options) run() error {
 	}
 	output = append(output, out...)
 
-	fmt.Fprint(o.Streams.Out, "upgraded completed successfully")
+	fmt.Fprint(o.Streams.Out, "upgraded completed successfully\n")
+
 	return apply.WriteOutput("", output)
 }


### PR DESCRIPTION
make output clear

```
# ./clusteradm upgrade clustermanager
clustermanager installed. starting upgrade
upgraded completed successfully

```

Signed-off-by: jichenjc <jichenjc@cn.ibm.com>