### PR TITLE
fix: use poll method to monitor namespace deletion

### DIFF
--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -11,4 +11,6 @@ const (
 	ClusterManagerName                = "cluster-manager"
 	LabelApp                          = "app"
 	BootstrapSecretPrefix             = "bootstrap-token-"
+	HubClusterNamespace               = "open-cluster-management-hub"
+	ManagedClusterNamespace           = "open-cluster-management-agent"
 )

--- a/test/e2e/e2e-test.mk
+++ b/test/e2e/e2e-test.mk
@@ -1,3 +1,5 @@
+export KUBECONFIG := ${HOME}/.kube/config
+
 export HUB_NAME := ${PROJECT_NAME}-e2e-test-hub
 export MANAGED_CLUSTER1_NAME := ${PROJECT_NAME}-e2e-test-c1
 export MANAGED_CLUSTER2_NAME := ${PROJECT_NAME}-e2e-test-c2

--- a/test/e2e/util/e2econf.go
+++ b/test/e2e/util/e2econf.go
@@ -5,6 +5,8 @@ type TestE2eConfig struct {
 	values     *values
 	clusteradm *clusteradm
 
+	Kubeconfigpath string
+
 	ClearEnv func()
 }
 
@@ -21,6 +23,7 @@ func (tec *TestE2eConfig) Clusteradm() clusteradmInterface {
 }
 
 func NewTestE2eConfig(
+	kubeconfigpath string,
 	hub string,
 	hubctx string,
 	mcl1 string,
@@ -49,7 +52,8 @@ func NewTestE2eConfig(
 	}
 
 	return &TestE2eConfig{
-		values:     &cfgval,
-		clusteradm: &clusteradm{},
+		values:         &cfgval,
+		clusteradm:     &clusteradm{},
+		Kubeconfigpath: kubeconfigpath,
 	}
 }

--- a/test/e2e/util/helper.go
+++ b/test/e2e/util/helper.go
@@ -1,0 +1,46 @@
+// Copyright Contributors to the Open Cluster Management project
+package util
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// WaitNamespaceDeleted receive a kubeconfigpath, a context name and a namespace name,
+// then poll until the specific namespace is fully deleted or an error occurs.
+func WaitNamespaceDeleted(kubeconfigpath string, ctx string, namespace string) error {
+	restcfg, err := buildConfigFromFlags(ctx, kubeconfigpath)
+	if err != nil {
+		return fmt.Errorf("error occurred while build rest config: %s", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restcfg)
+
+	return wait.PollImmediateInfinite(1*time.Second, func() (bool, error) {
+		_, err = clientset.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	})
+}
+
+// buildConfigFromFlags build rest config for specified context in the kubeconfigfile.
+func buildConfigFromFlags(context, kubeconfigPath string) (*rest.Config, error) {
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
+		&clientcmd.ConfigOverrides{
+			CurrentContext: context,
+		}).ClientConfig()
+}


### PR DESCRIPTION
Signed-off-by: ycyaoxdu <yaoyuchen0626@163.com>

Since the error `unable to create new content in namespace open-cluster-management-agent because it is being terminated` always leads to panic, use poll to monitor resources to be terminated.