### PR TITLE
clusteradm: provide darwin arm64 binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
           body_path: CHANGELOG.md
           files: |
             bin/clusteradm_darwin_amd64.tar.gz
+            bin/clusteradm_darwin_arm64.tar.gz
             bin/clusteradm_linux_amd64.tar.gz
             bin/clusteradm_linux_arm64.tar.gz
             bin/clusteradm_linux_ppc64le.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ build-bin:
 	@rm -rf bin
 	@mkdir -p bin
 	GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -gcflags=-trimpath=x/y -o bin/clusteradm ./cmd/clusteradm/clusteradm.go && tar -czf bin/clusteradm_darwin_amd64.tar.gz LICENSE -C bin/ clusteradm
+	GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -gcflags=-trimpath=x/y -o bin/clusteradm ./cmd/clusteradm/clusteradm.go && tar -czf bin/clusteradm_darwin_arm64.tar.gz LICENSE -C bin/ clusteradm
 	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -gcflags=-trimpath=x/y -o bin/clusteradm ./cmd/clusteradm/clusteradm.go && tar -czf bin/clusteradm_linux_amd64.tar.gz LICENSE -C bin/ clusteradm
 	GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -gcflags=-trimpath=x/y -o bin/clusteradm ./cmd/clusteradm/clusteradm.go && tar -czf bin/clusteradm_linux_arm64.tar.gz LICENSE -C bin/ clusteradm
 	GOOS=linux GOARCH=ppc64le go build -ldflags="-s -w" -gcflags=-trimpath=x/y -o bin/clusteradm ./cmd/clusteradm/clusteradm.go && tar -czf bin/clusteradm_linux_ppc64le.tar.gz LICENSE -C bin/ clusteradm

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ getSystemInfo() {
 }
 
 verifySupported() {
-    local supported=(darwin-amd64 linux-amd64 linux-arm64 windows-amd64)
+    local supported=(darwin-amd64 darwin-arm64 linux-amd64 linux-arm64 windows-amd64)
     local current_osarch="${OS}-${ARCH}"
 
     for osarch in "${supported[@]}"; do


### PR DESCRIPTION
I cannot run `curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash` command to install `clusteradm` on Mac M1.

This PR makes `clusteradm_darwin_arm64.tar.gz` available. 