### PR TITLE
fix: correct spelling of output table

### DIFF
--- a/pkg/cmd/get/cluster/exec.go
+++ b/pkg/cmd/get/cluster/exec.go
@@ -63,7 +63,7 @@ func converToTable(clusters *clusterapiv1.ManagedClusterList) *metav1.Table {
 			{Name: "ClusterSet", Type: "string"},
 			{Name: "CPU", Type: "string"},
 			{Name: "Memory", Type: "string"},
-			{Name: "Kuberenetes Version", Type: "string"},
+			{Name: "Kubernetes Version", Type: "string"},
 		},
 		Rows: []metav1.TableRow{},
 	}


### PR DESCRIPTION
Fixed typo for `Kubernetes version` column

`clusteradm get clusters`

NAME       ACCEPTED   AVAILABLE   CLUSTERSET   CPU   MEMORY      **KUBERENETES** VERSION
cluster1   true       True        default      4     3820860Ki   v1.23.4
cluster2   true       True        default      4     3820860Ki   v1.23.4
