### PR TITLE
Update PolicySet CRD to match propagator

### DIFF
--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/policy.open-cluster-management.io_policysets.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/policy.open-cluster-management.io_policysets.yaml
@@ -24,7 +24,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: PolicySet is the Schema for the policysets API
@@ -69,32 +69,6 @@ spec:
                     placementBinding:
                       type: string
                     placementRule:
-                      type: string
-                  type: object
-                type: array
-              results:
-                items:
-                  description: PolicySetStatusResult shows the compliance status of
-                    a policy in the set
-                  properties:
-                    clusters:
-                      items:
-                        description: PolicySetResultCluster shows the compliance status
-                          of a policy for a specific cluster
-                        properties:
-                          clusterName:
-                            type: string
-                          clusterNamespace:
-                            type: string
-                          compliant:
-                            type: string
-                        type: object
-                      type: array
-                    compliant:
-                      type: string
-                    message:
-                      type: string
-                    policy:
                       type: string
                   type: object
                 type: array


### PR DESCRIPTION
The CRD was changed back to v1beta1, following some discussions about
the readiness of the API.

Refs:
 - https://github.com/open-cluster-management-io/clusteradm/issues/210

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>