### PR TITLE
Fix `init` messaging

### DIFF
--- a/pkg/cmd/clean/exec.go
+++ b/pkg/cmd/clean/exec.go
@@ -47,7 +47,7 @@ func (o *Options) Validate() error {
 		return err
 	}
 	if !installed {
-		return fmt.Errorf("hub not be initialized")
+		return fmt.Errorf("hub has not been initialized")
 	}
 	return nil
 }

--- a/pkg/helpers/client.go
+++ b/pkg/helpers/client.go
@@ -197,14 +197,13 @@ func GetBootstrapSecretFromSA(
 		return nil, err
 	}
 	var secret *corev1.Secret
-	var prefix string
+	prefix := config.BootstrapSAName
+	if len(prefix) > 63 {
+		prefix = prefix[:37]
+	}
 	for _, objectRef := range sa.Secrets {
 		if objectRef.Namespace != "" && objectRef.Namespace != config.OpenClusterManagementNamespace {
 			continue
-		}
-		prefix = config.BootstrapSAName
-		if len(prefix) > 63 {
-			prefix = prefix[:37]
 		}
 		if strings.HasPrefix(objectRef.Name, prefix) {
 			secret, err = kubeClient.CoreV1().


### PR DESCRIPTION
Running the following environment:

```
kind: v0.13.0
Kubernetes: v1.24.0
Go: v1.18.1
```

The `clusteradm init` command failed to work. Using `--use-bootstrap-token` worked as a workaround, but I updated some of the code flows as a result of the issues.