### PR TITLE
Consistent flags/Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Install specific built-in add-on(s) to the hub cluster.
 
 Enable specific add-on(s) agent deployment to the given managed clusters of the specify namespace
 
-`clusteradm addon enable --name application-manager --namespace <namespace> --cluster <cluster1>,<cluster2>,....`
+`clusteradm addon enable --names application-manager --namespace <namespace> --clusters <cluster1>,<cluster2>,....`

--- a/pkg/cmd/accept/options.go
+++ b/pkg/cmd/accept/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 	//A list of comma separated cluster names
 	Clusters string

--- a/pkg/cmd/addon/disable/cmd.go
+++ b/pkg/cmd/addon/disable/cmd.go
@@ -12,12 +12,12 @@ import (
 )
 
 var example = `
-# Disable application-manager addon on speccified clusters
-%[1]s addon disable --name application-manager --cluster cluster1,cluster2
+# Disable application-manager addon on specified clusters
+%[1]s addon disable --names application-manager --clusters cluster1,cluster2
 # Disable application-manager addon on all clusters
-%[1]s addon disable --name application-manager --all-clusters
-# Disable application-manager addon to the given managed clusters of the specify namespace
-%[1]s addon disable --names application-manager --namespace <namespace> --cluster <cluster1>
+%[1]s addon disable --names application-manager --all-clusters
+# Disable application-manager addon to the given managed clusters in the specified namespace
+%[1]s addon disable --names application-manager --namespace <namespace> --clusters <cluster1>
 `
 
 // NewCmd...
@@ -50,8 +50,8 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&o.Names, "name", []string{}, "Names of the add-on to deploy (comma separated)")
-	cmd.Flags().StringSliceVar(&o.Clusters, "cluster", []string{}, "Names of the managed cluster to deploy the add-on to (comma separated)")
+	cmd.Flags().StringSliceVar(&o.Names, "names", []string{}, "Names of the add-on to deploy (comma separated)")
+	cmd.Flags().StringSliceVar(&o.Clusters, "clusters", []string{}, "Names of the managed cluster to deploy the add-on to (comma separated)")
 	cmd.Flags().BoolVar(&o.Allclusters, "all-clusters", false, "Make all managed clusters to disable the add-on")
 
 	return cmd

--- a/pkg/cmd/addon/disable/exec.go
+++ b/pkg/cmd/addon/disable/exec.go
@@ -35,7 +35,7 @@ func (o *Options) Validate() (err error) {
 	}
 
 	if o.Allclusters && len(o.Clusters) != 0 {
-		return fmt.Errorf("flag --all-cluster and --cluster can not be set together")
+		return fmt.Errorf("flag --all-clusters and --clusters can not be set together")
 	}
 	return nil
 }

--- a/pkg/cmd/addon/disable/options.go
+++ b/pkg/cmd/addon/disable/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 	//A list of comma separated addon names
 	Names []string

--- a/pkg/cmd/addon/enable/cmd.go
+++ b/pkg/cmd/addon/enable/cmd.go
@@ -13,9 +13,9 @@ import (
 
 var example = `
 # Enable addon on to the given managed clusters of the specify namespace
-%[1]s addon enable --name application-manager --namespace namespace --cluster cluster1,cluster2
+%[1]s addon enable --names application-manager --namespace namespace --clusters cluster1,cluster2
 # Enable application-manager addon specified clusters
-%[1]s addon enable --name application-manager --cluster cluster1,cluster2
+%[1]s addon enable --names application-manager --clusters cluster1,cluster2
 `
 
 // NewCmd...
@@ -48,9 +48,9 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 		},
 	}
 
-	cmd.Flags().StringSliceVar(&o.Names, "name", []string{}, "Names of the add-on to deploy (comma separated)")
+	cmd.Flags().StringSliceVar(&o.Names, "names", []string{}, "Names of the add-on to deploy (comma separated)")
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "open-cluster-management-agent-addon", "Specified namespace to addon addon")
-	cmd.Flags().StringSliceVar(&o.Clusters, "cluster", []string{}, "Names of the managed cluster to deploy the add-on to (comma separated)")
+	cmd.Flags().StringSliceVar(&o.Clusters, "clusters", []string{}, "Names of the managed cluster to deploy the add-on to (comma separated)")
 	cmd.Flags().StringVar(&o.OutputFile, "output-file", "", "The generated resources will be copied in the specified file")
 
 	return cmd

--- a/pkg/cmd/addon/enable/exec.go
+++ b/pkg/cmd/addon/enable/exec.go
@@ -47,7 +47,7 @@ func (o *Options) Validate() error {
 	}
 
 	if len(o.Clusters) == 0 {
-		return fmt.Errorf("clusters is misisng")
+		return fmt.Errorf("clusters is missing")
 	}
 
 	return nil

--- a/pkg/cmd/addon/enable/options.go
+++ b/pkg/cmd/addon/enable/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 	//A list of comma separated addon names
 	Names []string

--- a/pkg/cmd/clean/cmd.go
+++ b/pkg/cmd/clean/cmd.go
@@ -47,6 +47,6 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 
 	cmd.Flags().StringVar(&o.ClusterManageName, "name", "cluster-manager", "The name of the cluster manager resource")
 	cmd.Flags().StringVar(&o.OutputFile, "output-file", "", "The generated resources will be copied in the specified file")
-	cmd.Flags().BoolVar(&o.UseBootstrapToken, "use-bootstrap-token", false, "If set then the boostrap token will used instead of a service account token")
+	cmd.Flags().BoolVar(&o.UseBootstrapToken, "use-bootstrap-token", false, "If set then the bootstrap token will used instead of a service account token")
 	return cmd
 }

--- a/pkg/cmd/clean/options.go
+++ b/pkg/cmd/clean/options.go
@@ -9,7 +9,7 @@ import (
 
 //Options: The structure holding all the command-line options
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 	Values          Values
 	//The cluster manager resource name
@@ -20,7 +20,7 @@ type Options struct {
 	UseBootstrapToken bool
 }
 
-//Valus: The values used in the template
+//Values: The values used in the template
 type Values struct {
 	//The values related to the hub
 	Hub Hub `json:"hub"`

--- a/pkg/cmd/clusterset/bind/options.go
+++ b/pkg/cmd/clusterset/bind/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	Streams genericclioptions.IOStreams

--- a/pkg/cmd/clusterset/set/options.go
+++ b/pkg/cmd/clusterset/set/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	Streams genericclioptions.IOStreams

--- a/pkg/cmd/clusterset/unbind/options.go
+++ b/pkg/cmd/clusterset/unbind/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	Streams genericclioptions.IOStreams

--- a/pkg/cmd/create/clusterset/options.go
+++ b/pkg/cmd/create/clusterset/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	Streams genericclioptions.IOStreams

--- a/pkg/cmd/create/work/cmd.go
+++ b/pkg/cmd/create/work/cmd.go
@@ -13,7 +13,7 @@ import (
 
 var example = `
 # Create manifestwork on a specified managed cluster"
-%[1]s create work work-example -f xxx.yaml --cluster cluster1
+%[1]s create work work-example -f xxx.yaml --clusters cluster1
 `
 
 // NewCmd...
@@ -46,7 +46,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 		},
 	}
 
-	cmd.Flags().StringVar(&o.Cluster, "cluster", "", "Names of the managed cluster to apply work")
+	cmd.Flags().StringVar(&o.Cluster, "clusters", "", "Names of the managed cluster to apply work")
 	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", false, "Overwrite the existing work if it exists already")
 	o.FileNameFlags.AddFlags(cmd.Flags())
 

--- a/pkg/cmd/create/work/options.go
+++ b/pkg/cmd/create/work/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	Streams genericclioptions.IOStreams

--- a/pkg/cmd/delete/clusterset/options.go
+++ b/pkg/cmd/delete/clusterset/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	Streams genericclioptions.IOStreams

--- a/pkg/cmd/delete/token/options.go
+++ b/pkg/cmd/delete/token/options.go
@@ -8,7 +8,7 @@ import (
 
 //Options: The structure holding all the command-line options
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 }
 

--- a/pkg/cmd/delete/work/cmd.go
+++ b/pkg/cmd/delete/work/cmd.go
@@ -43,7 +43,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 		},
 	}
 
-	cmd.Flags().StringVar(&o.Cluster, "cluster", "", "Names of the managed cluster applied work")
+	cmd.Flags().StringVar(&o.Cluster, "cluster", "", "Name of the managed cluster applied work")
 	cmd.Flags().BoolVar(&o.Force, "force", false, "set force flag to enable force delete")
 
 	return cmd

--- a/pkg/cmd/delete/work/options.go
+++ b/pkg/cmd/delete/work/options.go
@@ -8,7 +8,7 @@ import (
 
 //Options: The structure holding all the command-line options
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	Streams genericclioptions.IOStreams

--- a/pkg/cmd/get/addon/options.go
+++ b/pkg/cmd/get/addon/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 	// A list of cluster to show
 	clusters []string

--- a/pkg/cmd/get/cluster/options.go
+++ b/pkg/cmd/get/cluster/options.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 	//Clusterset of the clusters
 	Clusterset string

--- a/pkg/cmd/get/clusterset/options.go
+++ b/pkg/cmd/get/clusterset/options.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	Streams genericclioptions.IOStreams

--- a/pkg/cmd/get/hubinfo/options.go
+++ b/pkg/cmd/get/hubinfo/options.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	Streams genericclioptions.IOStreams

--- a/pkg/cmd/get/klusterletinfo/options.go
+++ b/pkg/cmd/get/klusterletinfo/options.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	Streams genericclioptions.IOStreams

--- a/pkg/cmd/get/token/cmd.go
+++ b/pkg/cmd/get/token/cmd.go
@@ -44,7 +44,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	}
 
 	cmd.Flags().StringVar(&o.outputFile, "output-file", "", "The generated resources will be copied in the specified file")
-	cmd.Flags().BoolVar(&o.useBootstrapToken, "use-bootstrap-token", false, "If set then the boostrap token will used instead of a service account token")
+	cmd.Flags().BoolVar(&o.useBootstrapToken, "use-bootstrap-token", false, "If set then the bootstrap token will used instead of a service account token")
 
 	return cmd
 }

--- a/pkg/cmd/get/token/options.go
+++ b/pkg/cmd/get/token/options.go
@@ -8,7 +8,7 @@ import (
 
 //Options: The structure holding all the command-line options
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 	values          Values
 	//The file to output the resources will be sent to the file.
@@ -17,7 +17,7 @@ type Options struct {
 	useBootstrapToken bool
 }
 
-//Valus: The values used in the template
+//Values: The values used in the template
 type Values struct {
 	//The values related to the hub
 	Hub Hub `json:"hub"`

--- a/pkg/cmd/get/work/cmd.go
+++ b/pkg/cmd/get/work/cmd.go
@@ -47,7 +47,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 		},
 	}
 
-	cmd.Flags().StringVar(&o.cluster, "cluster", "", "Names of the managed cluster")
+	cmd.Flags().StringVar(&o.cluster, "cluster", "", "Name of the managed cluster")
 
 	return cmd
 }

--- a/pkg/cmd/get/work/options.go
+++ b/pkg/cmd/get/work/options.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 	//A list of comma separated cluster names
 	cluster string

--- a/pkg/cmd/init/cmd.go
+++ b/pkg/cmd/init/cmd.go
@@ -46,7 +46,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	}
 
 	cmd.Flags().StringVar(&o.outputFile, "output-file", "", "The generated resources will be copied in the specified file")
-	cmd.Flags().BoolVar(&o.useBootstrapToken, "use-bootstrap-token", false, "If set then the boostrap token will used instead of a service account token")
+	cmd.Flags().BoolVar(&o.useBootstrapToken, "use-bootstrap-token", false, "If set then the bootstrap token will used instead of a service account token")
 	cmd.Flags().BoolVar(&o.force, "force", false, "If set then the hub will be reinitialized")
 	cmd.Flags().StringVar(&o.registry, "image-registry", "quay.io/open-cluster-management",
 		"The name of the image registry serving OCM images, which will be applied to all the deploying OCM components.")

--- a/pkg/cmd/init/exec.go
+++ b/pkg/cmd/init/exec.go
@@ -33,7 +33,7 @@ func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
 	versionBundle, err := version.GetVersionBundle(o.bundleVersion)
 
 	if err != nil {
-		klog.Errorf("unable to retrive version ", err)
+		klog.Errorf("unable to retrieve version ", err)
 		return err
 	}
 

--- a/pkg/cmd/init/options.go
+++ b/pkg/cmd/init/options.go
@@ -8,7 +8,7 @@ import (
 
 //Options: The structure holding all the command-line options
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 	values          Values
 	//The file to output the resources will be sent to the file.
@@ -28,9 +28,9 @@ type Options struct {
 }
 
 type BundleVersion struct {
-	// registation image version
+	// registration image version
 	RegistrationImageVersion string
-	// placment image version
+	// placement image version
 	PlacementImageVersion string
 	// work image version
 	WorkImageVersion string
@@ -38,7 +38,7 @@ type BundleVersion struct {
 	OperatorImageVersion string
 }
 
-//Valus: The values used in the template
+//Values: The values used in the template
 type Values struct {
 	//The values related to the hub
 	Hub Hub `json:"hub"`

--- a/pkg/cmd/join/exec.go
+++ b/pkg/cmd/join/exec.go
@@ -43,7 +43,7 @@ func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
 	versionBundle, err := version.GetVersionBundle(o.bundleVersion)
 
 	if err != nil {
-		klog.Errorf("unable to retrive version ", err)
+		klog.Errorf("unable to retrieve version ", err)
 		return err
 	}
 
@@ -84,7 +84,7 @@ func (o *Options) validate() error {
 		return fmt.Errorf("token is missing")
 	}
 	if o.values.Hub.APIServer == "" {
-		return fmt.Errorf("hub-server is misisng")
+		return fmt.Errorf("hub-server is missing")
 	}
 	if o.values.ClusterName == "" {
 		return fmt.Errorf("name is missing")

--- a/pkg/cmd/join/options.go
+++ b/pkg/cmd/join/options.go
@@ -8,7 +8,7 @@ import (
 
 //Options: The structure holding all the command-line options
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 	//The token generated on the hub to access it from the cluster
 	token string
@@ -52,7 +52,7 @@ type Values struct {
 type Hub struct {
 	//APIServer: The API Server external URL
 	APIServer string
-	//KubeConfig: The kubeconfig of the boostrap secret to connect to the hub
+	//KubeConfig: The kubeconfig of the bootstrap secret to connect to the hub
 	KubeConfig string
 	//image registry
 	Registry string
@@ -65,9 +65,9 @@ type Klusterlet struct {
 }
 
 type BundleVersion struct {
-	// registation image version
+	// registration image version
 	RegistrationImageVersion string
-	// placment image version
+	// placement image version
 	PlacementImageVersion string
 	// work image version
 	WorkImageVersion string

--- a/pkg/cmd/proxy/health/cmd.go
+++ b/pkg/cmd/proxy/health/cmd.go
@@ -59,7 +59,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 		"Konnectivity proxy server's entry hostname")
 	cmd.Flags().IntVar(&o.proxyServerPort, "proxy-server-port", 8090,
 		"Konnectivity proxy server's entry port")
-	cmd.Flags().StringArrayVarP(&o.clusters, "cluster", "c", nil,
+	cmd.Flags().StringArrayVarP(&o.clusters, "clusters", "c", nil,
 		"The names of the clusters to probe")
 
 	return cmd

--- a/pkg/cmd/proxy/health/exec.go
+++ b/pkg/cmd/proxy/health/exec.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"net"
 	"net/http"
 	"net/url"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -72,7 +73,7 @@ func (o *Options) run(streams genericclioptions.IOStreams) error {
 	}
 	addonClient, err := addonv1alpha1client.NewForConfig(hubRestConfig)
 	if err != nil {
-		return errors.Wrapf(err, "failed newing addon api client")
+		return errors.Wrapf(err, "failed initializing addon api client")
 	}
 
 	clusterAddon, err := addonClient.AddonV1alpha1().ClusterManagementAddOns().Get(
@@ -98,7 +99,7 @@ func (o *Options) run(streams genericclioptions.IOStreams) error {
 
 	proxyClient, err := versioned.NewForConfig(hubRestConfig)
 	if err != nil {
-		return errors.Wrapf(err, "failed newing proxy api client")
+		return errors.Wrapf(err, "failed initializing proxy api client")
 	}
 	proxyConfig, err := proxyClient.ProxyV1alpha1().ManagedProxyConfigurations().
 		Get(context.TODO(), clusterAddon.Spec.AddOnConfiguration.CRName, metav1.GetOptions{})
@@ -108,7 +109,7 @@ func (o *Options) run(streams genericclioptions.IOStreams) error {
 
 	clusterClient, err := clusterv1.NewForConfig(hubRestConfig)
 	if err != nil {
-		return errors.Wrapf(err, "failed newing cluster client")
+		return errors.Wrapf(err, "failed initializing cluster client")
 	}
 	managedClusterList, err := clusterClient.ManagedClusters().List(
 		context.TODO(),

--- a/pkg/cmd/proxy/health/options.go
+++ b/pkg/cmd/proxy/health/options.go
@@ -8,7 +8,7 @@ import (
 
 //Options: The structure holding all the command-line options
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	clusters                 []string

--- a/pkg/cmd/proxy/kubectl/cmd.go
+++ b/pkg/cmd/proxy/kubectl/cmd.go
@@ -39,7 +39,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	cmd := &cobra.Command{
 		Use:   "kubectl",
 		Short: "Use kubectl through cluster-proxy addon.",
-		Long:  "Use kubectl through cluster-proxy addon.(only support managed service account token as certificate yet)",
+		Long:  "Use kubectl through cluster-proxy addon. (Only supports managed service account token as certificate.)",
 		Example: `If you want to get nodes on managed cluster named "cluster1", you can use the following command:
 		clusteradm proxy kubectl --cluster=cluster1 --sa=test --args="get nodes"`,
 		SilenceUsage: true,
@@ -135,7 +135,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	}
 
 	cmd.Flags().StringVar(&o.cluster, "cluster", "", "The name of the managed cluster")
-	cmd.Flags().StringVar(&o.managedServiceAccount, "sa", "", "the name of the managedServiceAccount")
+	cmd.Flags().StringVar(&o.managedServiceAccount, "sa", "", "The name of the managedServiceAccount")
 	cmd.Flags().StringVar(&o.kubectlArgs, "args", "", "The arguments to pass to kubectl")
 
 	return cmd
@@ -144,7 +144,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 func getProxyConfig(hubRestConfig *rest.Config, streams genericclioptions.IOStreams) (*proxyv1alpha1.ManagedProxyConfiguration, error) {
 	addonClient, err := addonv1alpha1client.NewForConfig(hubRestConfig)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed newing addon api client")
+		return nil, errors.Wrapf(err, "failed initializing addon api client")
 	}
 
 	clusterAddon, err := addonClient.AddonV1alpha1().ClusterManagementAddOns().Get(

--- a/pkg/cmd/proxy/kubectl/cmd.go
+++ b/pkg/cmd/proxy/kubectl/cmd.go
@@ -115,7 +115,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 				return errors.Wrapf(err, "failed listening http proxy server")
 			}
 
-			// Configurate a customized kubeconfig amd write into /tmp dir with a random name
+			// Configure a customized kubeconfig amd write into /tmp dir with a random name
 			tmpKubeconfigFilePath, err := genTmpKubeconfig(o.cluster, managedServiceAccountToken)
 			if err != nil {
 				return err
@@ -125,7 +125,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 
 			// Using kubectl to access the managed cluster using the above customized kubeconfig
 			// We are using combinedoutput, so err msg should include in result, no need to handle err
-			result, _ := runKubectlCommmand(tmpKubeconfigFilePath, o.kubectlArgs)
+			result, _ := runKubectlCommand(tmpKubeconfigFilePath, o.kubectlArgs)
 			if _, err = streams.Out.Write(result); err != nil {
 				return errors.Wrap(err, "streams out write failed")
 			}
@@ -170,7 +170,7 @@ func getProxyConfig(hubRestConfig *rest.Config, streams genericclioptions.IOStre
 
 	proxyClient, err := clusterproxyclient.NewForConfig(hubRestConfig)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed newing proxy api client")
+		return nil, errors.Wrapf(err, "failed initializing proxy api client")
 	}
 	proxyConfig, err := proxyClient.ProxyV1alpha1().ManagedProxyConfigurations().
 		Get(context.TODO(), clusterAddon.Spec.AddOnConfiguration.CRName, metav1.GetOptions{})
@@ -209,7 +209,7 @@ func getManagedServiceAccountToken(hubRestConfig *rest.Config, msaName string, n
 	return string(token), nil
 }
 
-// Configurate a tmp kubeconfig and store it in a tmp file
+// Configure a tmp kubeconfig and store it in a tmp file
 func genTmpKubeconfig(cluster string, msaToken string) (string, error) {
 	c := &clientcmdapi.Cluster{
 		Server:                "https://localhost:9090",
@@ -247,8 +247,8 @@ func genTmpKubeconfig(cluster string, msaToken string) (string, error) {
 	return tmpFile, nil
 }
 
-// Use runKubectlCommmand to access the managed cluster
-func runKubectlCommmand(kubeconfigFilePath string, args string) ([]byte, error) {
+// Use runKubectlCommand to access the managed cluster
+func runKubectlCommand(kubeconfigFilePath string, args string) ([]byte, error) {
 	cmd := exec.Command("kubectl", strings.Split(args, " ")...)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfigFilePath))
 	return cmd.CombinedOutput()

--- a/pkg/cmd/proxy/kubectl/http-proxy-server.go
+++ b/pkg/cmd/proxy/kubectl/http-proxy-server.go
@@ -132,7 +132,7 @@ func (s *httpProxyServer) handle(wr http.ResponseWriter, req *http.Request) {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true, // Skip server-auth for kube-apiserver
 		},
-		// golang http pkg automaticly upgrade http connection to http2 connection, but http2 can not upgrade to SPDY which used in "kubectl exec".
+		// golang http pkg automatically upgrade http connection to http2 connection, but http2 can not upgrade to SPDY which used in "kubectl exec".
 		// set ForceAttemptHTTP2 = false to prevent auto http2 upgration
 		ForceAttemptHTTP2: false,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/pkg/cmd/proxy/kubectl/options.go
+++ b/pkg/cmd/proxy/kubectl/options.go
@@ -8,7 +8,7 @@ import (
 
 // Options: only support use in-cluster certificates
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	cluster               string

--- a/pkg/cmd/unjoin/exec.go
+++ b/pkg/cmd/unjoin/exec.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	klusterletclient "open-cluster-management.io/api/client/operator/clientset/versioned"
-	appliedwrokclient "open-cluster-management.io/api/client/work/clientset/versioned"
+	appliedworkclient "open-cluster-management.io/api/client/work/clientset/versioned"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 	"open-cluster-management.io/clusteradm/pkg/helpers/apply"
 )
@@ -55,7 +55,7 @@ func (o *Options) run() error {
 	if err != nil {
 		log.Fatal(err)
 	}
-	appliedWorkClient, err := appliedwrokclient.NewForConfig(config)
+	appliedWorkClient, err := appliedworkclient.NewForConfig(config)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -132,7 +132,7 @@ func WaitResourceToBeDelete(context context.Context, client klusterletclient.Int
 	return errGet
 
 }
-func IsAppliedManifestWorkExist(client appliedwrokclient.Interface) bool {
+func IsAppliedManifestWorkExist(client appliedworkclient.Interface) bool {
 	obj, err := client.WorkV1().AppliedManifestWorks().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/cmd/unjoin/options.go
+++ b/pkg/cmd/unjoin/options.go
@@ -8,7 +8,7 @@ import (
 
 //Options: The structure holding all the command-line options
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 	//The name under the cluster must be imported
 	clusterName string

--- a/pkg/cmd/upgrade/clustermanager/exec.go
+++ b/pkg/cmd/upgrade/clustermanager/exec.go
@@ -26,7 +26,7 @@ func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
 	versionBundle, err := version.GetVersionBundle(o.bundleVersion)
 
 	if err != nil {
-		klog.Errorf("unable to retrive version ", err)
+		klog.Errorf("unable to retrieve version ", err)
 		return err
 	}
 

--- a/pkg/cmd/upgrade/clustermanager/options.go
+++ b/pkg/cmd/upgrade/clustermanager/options.go
@@ -8,7 +8,7 @@ import (
 
 //Options: The structure holding all the command-line options
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	values Values
@@ -23,7 +23,7 @@ type Options struct {
 }
 
 type BundleVersion struct {
-	// registation image version
+	// registration image version
 	RegistrationImageVersion string
 	// placement image version
 	PlacementImageVersion string
@@ -46,7 +46,7 @@ type Values struct {
 type Hub struct {
 	//APIServer: The API Server external URL
 	APIServer string
-	//KubeConfig: The kubeconfig of the boostrap secret to connect to the hub
+	//KubeConfig: The kubeconfig of the bootstrap secret to connect to the hub
 	KubeConfig string
 	//image registry
 	Registry string

--- a/pkg/cmd/upgrade/klusterlet/exec.go
+++ b/pkg/cmd/upgrade/klusterlet/exec.go
@@ -55,7 +55,7 @@ func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
 	versionBundle, err := version.GetVersionBundle(o.bundleVersion)
 
 	if err != nil {
-		klog.Errorf("unable to retrive version ", err)
+		klog.Errorf("unable to retrieve version ", err)
 		return err
 	}
 

--- a/pkg/cmd/upgrade/klusterlet/options.go
+++ b/pkg/cmd/upgrade/klusterlet/options.go
@@ -8,7 +8,7 @@ import (
 
 //Options: The structure holding all the command-line options
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 	values Values
@@ -23,7 +23,7 @@ type Options struct {
 }
 
 type BundleVersion struct {
-	// registation image version
+	// registration image version
 	RegistrationImageVersion string
 	// placement image version
 	PlacementImageVersion string
@@ -54,7 +54,7 @@ type Klusterlet struct {
 type Hub struct {
 	//APIServer: The API Server external URL
 	APIServer string
-	//KubeConfig: The kubeconfig of the boostrap secret to connect to the hub
+	//KubeConfig: The kubeconfig of the bootstrap secret to connect to the hub
 	KubeConfig string
 	//image registry
 	Registry string

--- a/pkg/cmd/version/options.go
+++ b/pkg/cmd/version/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Options struct {
-	//ClusteradmFlags: The generic optiosn from the clusteradm cli-runtime.
+	//ClusteradmFlags: The generic options from the clusteradm cli-runtime.
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 }
 

--- a/pkg/helpers/asset/embedFSReader.go
+++ b/pkg/helpers/asset/embedFSReader.go
@@ -13,7 +13,7 @@ import (
 )
 
 type ScenarioReader interface {
-	//Retreive an asset from the data source
+	//Retrieve an asset from the data source
 	Asset(templatePath string) ([]byte, error)
 	//List all available assets in the data source
 	AssetNames(excluded []string) ([]string, error)
@@ -93,8 +93,8 @@ func isExcluded(f string, excluded []string) bool {
 	return false
 }
 
-func (r *ScenarioResourcesReader) ExtractAssets(prefix, dir string, exclusded []string) error {
-	assetNames, err := r.AssetNames(exclusded)
+func (r *ScenarioResourcesReader) ExtractAssets(prefix, dir string, excluded []string) error {
+	assetNames, err := r.AssetNames(excluded)
 	if err != nil {
 		return err
 	}

--- a/pkg/helpers/client.go
+++ b/pkg/helpers/client.go
@@ -137,7 +137,7 @@ func WaitCRDToBeReady(apiExtensionsClient apiextensionsclient.Interface, name st
 }
 
 //GetToken returns the bootstrap token.
-//It searchs first for the service-account token and then if it is not found
+//It searches first for the service-account token and then if it is not found
 //it looks for the bootstrap token in kube-system.
 func GetToken(kubeClient kubernetes.Interface) (string, TokenType, error) {
 	token, err := GetBootstrapTokenFromSA(kubeClient)

--- a/pkg/helpers/version/version.go
+++ b/pkg/helpers/version/version.go
@@ -34,7 +34,7 @@ func GetVersionBundle(version string) (VersionBundle, error) {
 		Operator:     "latest",
 	}
 
-	// predifined bundle version
+	// predefined bundle version
 	// TODO: automated version tracking
 	versionBundleList["0.5.0"] = VersionBundle{
 		Registration: "v0.5.0",


### PR DESCRIPTION
- Makes flags more consistent (eg. differentiating between `--name` for a single string and `--names` for an array of strings).
- Also fixes spelling errors I found.