### PR TITLE
update wording to make error clear

### DIFF
--- a/pkg/cmd/delete/clusterset/exec.go
+++ b/pkg/cmd/delete/clusterset/exec.go
@@ -55,7 +55,7 @@ func (o *Options) runWithClient(clusterClient clusterclientset.Interface,
 	_, err := clusterClient.ClusterV1beta1().ManagedClusterSets().Get(context.TODO(), clusterset, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			fmt.Fprintf(o.Streams.Out, "Clusterset %s is already deleted\n", clusterset)
+			fmt.Fprintf(o.Streams.Out, "Clusterset %s not found or is already deleted\n", clusterset)
 			return nil
 		}
 		return err


### PR DESCRIPTION
```
# clusteradm delete clusterset default1
Clusterset default1 is already deleted

```

I don't have default1 created.. so it's confusing output


Signed-off-by: jichenjc <jichenjc@cn.ibm.com>