### PR TITLE
Fix policy addon clusterrole missing events API permissions.

### DIFF
--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/addon-controller_clusterrole.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/addon-controller_clusterrole.yaml
@@ -115,6 +115,19 @@ rules:
   - apiGroups:
       - ""
     resourceNames:
+      - events
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resourceNames:
       - policy-encryption-key
     resources:
       - secrets


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Discovered, fixed and tested by @dgorst