### PR TITLE
sync governance-policy-addon-controller deployment image

### DIFF
--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/addon-controller_deployment.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/addon-controller_deployment.yaml
@@ -33,12 +33,10 @@ spec:
                   fieldPath: metadata.name
             - name: CONFIG_POLICY_CONTROLLER_IMAGE
               value: quay.io/open-cluster-management/config-policy-controller:latest
-            - name: GOVERNANCE_POLICY_SPEC_SYNC_IMAGE
-              value: quay.io/open-cluster-management/governance-policy-spec-sync:latest
-            - name: GOVERNANCE_POLICY_STATUS_SYNC_IMAGE
-              value: quay.io/open-cluster-management/governance-policy-status-sync:latest
-            - name: GOVERNANCE_POLICY_TEMPLATE_SYNC_IMAGE
-              value: quay.io/open-cluster-management/governance-policy-template-sync:latest
+            - name: KUBE_RBAC_PROXY_IMAGE
+              value: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10
+            - name: GOVERNANCE_POLICY_FRAMEWORK_ADDON_IMAGE
+              value: quay.io/open-cluster-management/governance-policy-framework-addon:latest
           image: quay.io/open-cluster-management/governance-policy-addon-controller:latest
           imagePullPolicy: IfNotPresent
           name: manager


### PR DESCRIPTION
Fix below error when I try to deploy the synchronization components to the managed cluster(s) following steps in
https://open-cluster-management.io/getting-started/integration/policy-framework/#deploy-the-synchronization-components-to-the-managed-clusters.

On managed cluster reports below error:
```
$ oc logs -n open-cluster-management-agent klusterlet-work-agent-858b76c7d-sjhpk
....
E1014 08:17:11.448118       1 base_controller.go:270] "ManifestWorkAgent" controller failed to sync "addon-governance-policy-framework-deploy", err: Deployment.apps "governance-policy-framework" is invalid: spec.template.spec.containers[0].image: Required value
```

Update the image refer to PR https://github.com/open-cluster-management-io/governance-policy-addon-controller/pull/25.

Signed-off-by: haoqing0110 <qhao@redhat.com>