### PR TITLE
Pin the OCM version for add-ons

### DIFF
--- a/pkg/cmd/install/hubaddon/cmd.go
+++ b/pkg/cmd/install/hubaddon/cmd.go
@@ -48,8 +48,9 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	}
 
 	cmd.Flags().StringVar(&o.names, "names", "", "Names of the built-in add-on to install (comma separated). The built-in add-ons are: application-manager, governance-policy-framework")
-	cmd.Flags().StringVar(&o.values.Namespace, "namespace", "open-cluster-management", "Namespace of the built-in add-on to install. Default to open-cluster-management")
+	cmd.Flags().StringVar(&o.values.Namespace, "namespace", "open-cluster-management", "Namespace of the built-in add-on to install. Defaults to open-cluster-management")
 	cmd.Flags().StringVar(&o.outputFile, "output-file", "", "The generated resources will be copied in the specified file")
+	cmd.Flags().StringVar(&o.bundleVersion, "bundle-version", "default", "The image version tag to use when deploying the hub add-on")
 
 	return cmd
 }

--- a/pkg/cmd/install/hubaddon/exec.go
+++ b/pkg/cmd/install/hubaddon/exec.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"open-cluster-management.io/clusteradm/pkg/cmd/install/hubaddon/scenario"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
+	"open-cluster-management.io/clusteradm/pkg/helpers/version"
 )
 
 const (
@@ -42,6 +43,18 @@ func (o *Options) validate() error {
 		default:
 			return fmt.Errorf("invalid add-on name %s", n)
 		}
+	}
+
+	versionBundle, err := version.GetVersionBundle(o.bundleVersion)
+
+	if err != nil {
+		klog.Errorf("unable to retrieve version "+o.bundleVersion, err)
+		return err
+	}
+
+	o.values.BundleVersion = BundleVersion{
+		AppAddon:    versionBundle.AppAddon,
+		PolicyAddon: versionBundle.PolicyAddon,
 	}
 
 	return nil

--- a/pkg/cmd/install/hubaddon/exec_test.go
+++ b/pkg/cmd/install/hubaddon/exec_test.go
@@ -13,6 +13,7 @@ import (
 const (
 	invalidNamespace = "no-such-ns"
 	ocmNamespace     = "open-cluster-management"
+	ocmVersion       = "latest"
 
 	invalidAddon           = "no-such-addon"
 	channelDeployment      = "multicluster-operators-channel"
@@ -22,6 +23,26 @@ const (
 )
 
 var _ = ginkgo.Describe("install hub-addon", func() {
+	ginkgo.Context("validate", func() {
+
+		ginkgo.It("Should not create any built-in add-on deployment(s) because it's not a valid add-on name", func() {
+			o := Options{
+				names: invalidAddon,
+			}
+
+			err := o.validate()
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("Should not create any built-in add-on deployment(s) because it's not a valid version", func() {
+			o := Options{
+				bundleVersion: "invalid",
+			}
+
+			err := o.validate()
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+		})
+	})
 
 	ginkgo.Context("runWithClient", func() {
 
@@ -62,6 +83,7 @@ var _ = ginkgo.Describe("install hub-addon", func() {
 
 		ginkgo.It("Should not create any built-in add-on deployment(s) because it's not a valid namespace", func() {
 			o := Options{
+				bundleVersion: ocmVersion,
 				values: Values{
 					Namespace: invalidNamespace,
 					hubAddons: []string{appMgrAddonName},
@@ -77,6 +99,9 @@ var _ = ginkgo.Describe("install hub-addon", func() {
 				values: Values{
 					Namespace: ocmNamespace,
 					hubAddons: []string{appMgrAddonName},
+					BundleVersion: BundleVersion{
+						AppAddon: ocmVersion,
+					},
 				},
 			}
 
@@ -105,6 +130,9 @@ var _ = ginkgo.Describe("install hub-addon", func() {
 				values: Values{
 					hubAddons: []string{policyFrameworkAddonName},
 					Namespace: ocmNamespace,
+					BundleVersion: BundleVersion{
+						PolicyAddon: ocmVersion,
+					},
 				},
 			}
 

--- a/pkg/cmd/install/hubaddon/options.go
+++ b/pkg/cmd/install/hubaddon/options.go
@@ -12,15 +12,25 @@ type Options struct {
 	//A list of comma separated addon names
 	names string
 	//The file to output the resources will be sent to the file.
-	outputFile string
-	values     Values
+	outputFile    string
+	values        Values
+	bundleVersion string
 }
 
-//Values: The values used in the template
+type BundleVersion struct {
+	// app image version
+	AppAddon string
+	// policy image version
+	PolicyAddon string
+}
+
+// Values: The values used in the template
 type Values struct {
 	hubAddons []string
 	// Namespace to install
 	Namespace string
+	// Version to install
+	BundleVersion BundleVersion
 }
 
 func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, streams genericclioptions.IOStreams) *Options {

--- a/pkg/cmd/install/hubaddon/scenario/addon/appmgr/deployment_appsubsummary.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/appmgr/deployment_appsubsummary.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: multicluster-operators-subscription
       containers:
         - name: multicluster-operators-appsub-summary
-          image: quay.io/open-cluster-management/multicloud-operators-subscription:latest
+          image: quay.io/open-cluster-management/multicloud-operators-subscription:{{ .BundleVersion.AppAddon }}
           ports:
           - containerPort: 9443
           command:

--- a/pkg/cmd/install/hubaddon/scenario/addon/appmgr/deployment_channel.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/appmgr/deployment_channel.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: multicluster-operators-subscription
       containers:
         - name: multicluster-operators-channel
-          image: quay.io/open-cluster-management/multicloud-operators-channel:latest
+          image: quay.io/open-cluster-management/multicloud-operators-channel:{{ .BundleVersion.AppAddon }}
           ports:
           - containerPort: 7443
           command:

--- a/pkg/cmd/install/hubaddon/scenario/addon/appmgr/deployment_placementrule.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/appmgr/deployment_placementrule.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: multicluster-operators-subscription
       containers:
         - name: multicluster-operators-placementrule
-          image: quay.io/open-cluster-management/multicloud-operators-subscription:latest
+          image: quay.io/open-cluster-management/multicloud-operators-subscription:{{ .BundleVersion.AppAddon }}
           ports:
           - containerPort: 6443
           command:

--- a/pkg/cmd/install/hubaddon/scenario/addon/appmgr/deployment_subscription.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/appmgr/deployment_subscription.yaml
@@ -19,13 +19,13 @@ spec:
       serviceAccountName: multicluster-operators-subscription
       containers:
         - name: multicluster-operators-subscription
-          image: quay.io/open-cluster-management/multicloud-operators-subscription:latest
+          image: quay.io/open-cluster-management/multicloud-operators-subscription:{{ .BundleVersion.AppAddon }}
           ports:
           - containerPort: 8443
           command:
           - /usr/local/bin/multicluster-operators-subscription
           - --sync-interval=60
-          - --agent-image=quay.io/open-cluster-management/multicloud-operators-subscription:latest
+          - --agent-image=quay.io/open-cluster-management/multicloud-operators-subscription:{{ .BundleVersion.AppAddon }}
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/addon-controller_deployment.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/addon-controller_deployment.yaml
@@ -32,12 +32,12 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: CONFIG_POLICY_CONTROLLER_IMAGE
-              value: quay.io/open-cluster-management/config-policy-controller:latest
+              value: quay.io/open-cluster-management/config-policy-controller:{{ .BundleVersion.PolicyAddon }}
             - name: KUBE_RBAC_PROXY_IMAGE
               value: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10
             - name: GOVERNANCE_POLICY_FRAMEWORK_ADDON_IMAGE
-              value: quay.io/open-cluster-management/governance-policy-framework-addon:latest
-          image: quay.io/open-cluster-management/governance-policy-addon-controller:latest
+              value: quay.io/open-cluster-management/governance-policy-framework-addon:{{ .BundleVersion.PolicyAddon }}
+          image: quay.io/open-cluster-management/governance-policy-addon-controller:{{ .BundleVersion.PolicyAddon }}
           imagePullPolicy: IfNotPresent
           name: manager
           resources:

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/addon-controller_deployment.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/addon-controller_deployment.yaml
@@ -33,10 +33,16 @@ spec:
                   fieldPath: metadata.name
             - name: CONFIG_POLICY_CONTROLLER_IMAGE
               value: quay.io/open-cluster-management/config-policy-controller:{{ .BundleVersion.PolicyAddon }}
-            - name: KUBE_RBAC_PROXY_IMAGE
-              value: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10
+            - name: GOVERNANCE_POLICY_SPEC_SYNC_IMAGE
+              value: quay.io/open-cluster-management/governance-policy-spec-sync:{{ .BundleVersion.PolicyAddon }}
+            - name: GOVERNANCE_POLICY_STATUS_SYNC_IMAGE
+              value: quay.io/open-cluster-management/governance-policy-status-sync:{{ .BundleVersion.PolicyAddon }}
+            - name: GOVERNANCE_POLICY_TEMPLATE_SYNC_IMAGE
+              value: quay.io/open-cluster-management/governance-policy-template-sync:{{ .BundleVersion.PolicyAddon }}
             - name: GOVERNANCE_POLICY_FRAMEWORK_ADDON_IMAGE
               value: quay.io/open-cluster-management/governance-policy-framework-addon:{{ .BundleVersion.PolicyAddon }}
+            - name: KUBE_RBAC_PROXY_IMAGE
+              value: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10
           image: quay.io/open-cluster-management/governance-policy-addon-controller:{{ .BundleVersion.PolicyAddon }}
           imagePullPolicy: IfNotPresent
           name: manager

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_deployment.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_deployment.yaml
@@ -30,7 +30,7 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: governance-policy-propagator
-        image: quay.io/open-cluster-management/governance-policy-propagator:latest
+        image: quay.io/open-cluster-management/governance-policy-propagator:{{ .BundleVersion.PolicyAddon }}
         imagePullPolicy: Always
         name: governance-policy-propagator
         ports:

--- a/pkg/helpers/version/version.go
+++ b/pkg/helpers/version/version.go
@@ -11,6 +11,8 @@ type VersionBundle struct {
 	Placement    string
 	Work         string
 	Operator     string
+	AppAddon     string
+	PolicyAddon  string
 }
 
 var defaultBundleVersion = "0.9.0"
@@ -32,6 +34,8 @@ func GetVersionBundle(version string) (VersionBundle, error) {
 		Placement:    "latest",
 		Work:         "latest",
 		Operator:     "latest",
+		AppAddon:     "latest",
+		PolicyAddon:  "latest",
 	}
 
 	// predefined bundle version
@@ -41,6 +45,8 @@ func GetVersionBundle(version string) (VersionBundle, error) {
 		Placement:    "v0.2.0",
 		Work:         "v0.5.0",
 		Operator:     "v0.5.0",
+		AppAddon:     "v0.5.0",
+		PolicyAddon:  "v0.8.0",
 	}
 
 	versionBundleList["0.6.0"] = VersionBundle{
@@ -48,6 +54,8 @@ func GetVersionBundle(version string) (VersionBundle, error) {
 		Placement:    "v0.3.0",
 		Work:         "v0.6.0",
 		Operator:     "v0.6.0",
+		AppAddon:     "v0.6.0",
+		PolicyAddon:  "v0.8.0",
 	}
 
 	versionBundleList["0.7.0"] = VersionBundle{
@@ -55,6 +63,8 @@ func GetVersionBundle(version string) (VersionBundle, error) {
 		Placement:    "v0.4.0",
 		Work:         "v0.7.0",
 		Operator:     "v0.7.0",
+		AppAddon:     "v0.7.0",
+		PolicyAddon:  "v0.8.0",
 	}
 
 	versionBundleList["0.8.0"] = VersionBundle{
@@ -62,6 +72,8 @@ func GetVersionBundle(version string) (VersionBundle, error) {
 		Placement:    "v0.8.0",
 		Work:         "v0.8.0",
 		Operator:     "v0.8.0",
+		AppAddon:     "v0.8.0",
+		PolicyAddon:  "v0.8.0",
 	}
 
 	versionBundleList["0.9.0"] = VersionBundle{
@@ -69,6 +81,8 @@ func GetVersionBundle(version string) (VersionBundle, error) {
 		Placement:    "v0.9.0",
 		Work:         "v0.9.0",
 		Operator:     "v0.9.0",
+		AppAddon:     "v0.9.0",
+		PolicyAddon:  "v0.9.0",
 	}
 
 	// default


### PR DESCRIPTION
This PR made us realize that always pulling the `latest` image could cause problems:
- #279 

This pins the version to the latest OCM, but this is configurable if a user wants to pass `--version=latest`.