### PR TITLE
Fix: preflight check should return no error when configmap cluster-info not exist.

### DIFF
--- a/pkg/cmd/join/exec.go
+++ b/pkg/cmd/join/exec.go
@@ -107,7 +107,7 @@ func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
 	}
 	klusterletApiserver, err := helpers.GetAPIServer(kubeClient)
 	if err != nil {
-		klog.Errorf("Failed looking for cluster endpoint for the registering klusterlet: %v", err)
+		klog.Warningf("Failed looking for cluster endpoint for the registering klusterlet: %v", err)
 		klusterletApiserver = ""
 	}
 	o.values.Klusterlet.APIServer = klusterletApiserver

--- a/pkg/cmd/join/preflight/checks.go
+++ b/pkg/cmd/join/preflight/checks.go
@@ -14,6 +14,11 @@ type KlusterletApiserverCheck struct {
 }
 
 func (c KlusterletApiserverCheck) Check() (warningList []string, errorList []error) {
+	if c.KlusterletApiserver == "" {
+		return []string{
+			"No klusterlet apiserver set, so the managed cluster has no externally accessible url that hub cluster can visit.",
+		}, nil
+	}
 	if !validAPIHost(c.KlusterletApiserver) {
 		return nil, []error{errors.New("ConfigMap/cluster-info.data.kubeconfig.clusters[0].cluster.server field in namespace kube-public should start with http:// or https://, please edit it first")}
 	}


### PR DESCRIPTION
Signed-off-by: xuezhaojun <zxue@redhat.com>