### PR TITLE
Fix typo

### DIFF
--- a/pkg/cmd/upgrade/cmd.go
+++ b/pkg/cmd/upgrade/cmd.go
@@ -13,7 +13,7 @@ import (
 func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade",
-		Short: "upgrade componenet",
+		Short: "upgrade component",
 	}
 
 	cmd.AddCommand(klusterlet.NewCmd(clusteradmFlags, streams))


### PR DESCRIPTION
Fix typo in command help on CLI