### PR TITLE
Bug Fix: remove bootstratp secret during clean

### DIFF
--- a/pkg/cmd/clean/exec.go
+++ b/pkg/cmd/clean/exec.go
@@ -137,9 +137,10 @@ func (o *Options) removeBootStrapSecret(client kubernetes.Interface) error {
 	if err != nil && !errors.IsNotFound(err) {
 		errs = append(errs, err)
 	}
+	listOpts := metav1.ListOptions{LabelSelector: "app=cluster-manager"}
 	err = client.CoreV1().
 		Secrets("kube-system").
-		Delete(context.Background(), "bootstrap-token-"+o.Values.Hub.TokenID, metav1.DeleteOptions{})
+		DeleteCollection(context.Background(), metav1.DeleteOptions{}, listOpts)
 	if err != nil && !errors.IsNotFound(err) {
 		errs = append(errs, err)
 	}


### PR DESCRIPTION
clusteradm clean didn't remove the boostrap-token in kube-system #314

see: https://github.com/open-cluster-management-io/clusteradm/issues/314