### PR TITLE
Add interactiveMode in proxy.

### DIFF
--- a/pkg/cmd/proxy/kubectl/options.go
+++ b/pkg/cmd/proxy/kubectl/options.go
@@ -14,6 +14,7 @@ type Options struct {
 	ClusterOption         *genericclioptionsclusteradm.ClusterOption
 	managedServiceAccount string
 	kubectlArgs           string
+	interactiveMode       bool
 }
 
 func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags) *Options {


### PR DESCRIPTION
This allows users to interact with managed clusters without constructing a clusteradm command everytime.
```bash
➜  ~ clusteradm proxy kubectl --cluster=cluster1 --sa=test -i
Please enter the kubectl command and use "exit" to quit the interactive mode
kubectl> get nodes
NAME                     STATUS   ROLES                  AGE   VERSION
cluster1-control-plane   Ready    control-plane,master   51m   v1.21.1
kubectl> get pods
No resources found in default namespace.
kubectl> get serviceaccount
NAME      SECRETS   AGE
default   1         51m
kubectl> exit
Exit from interactive mode
```