### PR TITLE
ci: prevent fossa workflow from runing and failing when syncing forks

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   fossa-scan:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'open-cluster-management-io'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
