### PR TITLE
Fix: e2e fails because not support latest bundles.

### DIFF
--- a/pkg/cmd/init/scenario/init/clustermanager_cluster_role.yaml
+++ b/pkg/cmd/init/scenario/init/clustermanager_cluster_role.yaml
@@ -1,4 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
+# Copied from https://github.com/open-cluster-management-io/ocm/blob/main/deploy/cluster-manager/config/rbac/cluster_role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -10,7 +11,7 @@ rules:
   verbs: ["create", "get", "list", "update", "watch", "patch", "delete", "deletecollection"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "list", "watch", "update", "patch", "delete"]
+  verbs: ["list", "watch", "update", "patch", "delete"]
   resourceNames:
     - "signer-secret"
     - "registration-webhook-serving-cert"
@@ -21,9 +22,10 @@ rules:
     - "placement-controller-sa-kubeconfig"
     - "work-controller-sa-kubeconfig"
     - "external-hub-kubeconfig"
+# addon manager needs this to sign the customized type csr
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create"]
+  verbs: ["create", "get"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["create", "get", "list", "update", "watch", "patch", "delete"]
@@ -67,7 +69,7 @@ rules:
 # Allow the nuclues to manage clustermanager apis.
 - apiGroups: ["operator.open-cluster-management.io"]
   resources: ["clustermanagers"]
-  verbs: ["get", "list", "watch", "update", "delete"]
+  verbs: ["get", "list", "watch", "update", "delete", "patch"]
 - apiGroups: ["operator.open-cluster-management.io"]
   resources: ["clustermanagers/status"]
   verbs: ["update", "patch"]
@@ -83,8 +85,11 @@ rules:
   resources: ["managedclusteraddons/status", "clustermanagementaddons/status"]
   verbs: ["patch", "update"]
 - apiGroups: ["addon.open-cluster-management.io"]
-  resources: ["managedclusteraddons/finalizers", "clustermanagementaddons/finalizers"]
+  resources: [managedclusteraddons/finalizers, "clustermanagementaddons/finalizers"]
   verbs: ["update"]
+- apiGroups: ["addon.open-cluster-management.io"]
+  resources: [addondeploymentconfigs, "addontemplates"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
   verbs: ["create"]
@@ -96,8 +101,7 @@ rules:
   verbs: ["update"]
 - apiGroups: ["certificates.k8s.io"]
   resources: ["signers"]
-  resourceNames: ["kubernetes.io/kube-apiserver-client"]
-  verbs: ["approve"]
+  verbs: ["approve", "sign"]
 - apiGroups: ["cluster.open-cluster-management.io"]
   resources: ["managedclusters"]
   verbs: ["get", "list", "watch", "update", "patch"]
@@ -117,7 +121,7 @@ rules:
   resources: ["managedclusters/clientcertificates"]
   verbs: ["renew"]
 - apiGroups: ["register.open-cluster-management.io"]
-  resources: ["managedclusters/accept" ]
+  resources: ["managedclusters/accept"]
   verbs: ["update"]
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["manifestworkreplicasets"]

--- a/pkg/cmd/join/scenario/join/cluster_role.yaml
+++ b/pkg/cmd/join/scenario/join/cluster_role.yaml
@@ -1,4 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
+# Copied from: https://github.com/open-cluster-management-io/ocm/blob/main/deploy/klusterlet/config/rbac/cluster_role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -46,4 +47,4 @@ rules:
 # Allow the registration-operator to update the appliedmanifestworks finalizer.
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["appliedmanifestworks"]
-  verbs: ["list", "update"]
+  verbs: ["list", "update", "patch"]


### PR DESCRIPTION
Fixes: 
* https://github.com/open-cluster-management-io/clusteradm/actions/runs/5423857040/jobs/9862392036?pr=348
* https://github.com/open-cluster-management-io/clusteradm/actions/runs/5319342206/jobs/9631726852?pr=349

---

In `clusteradm` e2e, we should depend on a stable version of bundles, otherwise any bugs or new features imported in "registration-operator", "registration", "work" or other repos, will **break or block the development of clusteradm**.

**Recommended practice**: we can make a task to "Make clusteradm support 0.12.0" when we want to release 0.12.0 binaries.

Because **we can't always promise** the compatibility between latest `clusteradm` and the latest bundles, which would exhaust us.  

So any developer who uses `clusteradm` to deploy `latest` bundles should know **the risk** that there might be compatibility issues.