### PR TITLE
Using the right API version v1alpha1 for ClusterClaims

### DIFF
--- a/pkg/helpers/check/check.go
+++ b/pkg/helpers/check/check.go
@@ -9,6 +9,7 @@ import (
 	clusterclient "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 )
 
@@ -54,14 +55,14 @@ func CheckForKlusterletCRD(client operatorclient.Interface) error {
 func CheckForManagedCluster(client clusterclient.Interface) error {
 	msg := "managed cluster oriented command should not running against non-managed cluster"
 
-	list, err := client.Discovery().ServerResourcesForGroupVersion(clusterv1.GroupVersion.String())
+	list, err := client.Discovery().ServerResourcesForGroupVersion(clusterv1alpha1.GroupVersion.String())
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return fmt.Errorf(msg)
 
 		}
-		return fmt.Errorf("failed to list GroupVersion: %s", clusterv1.GroupVersion.String())
 
+		return fmt.Errorf("failed to list GroupVersion: %s", clusterv1alpha1.GroupVersion.String())
 	}
 	flag := findResource(list, ClusterClaimResourceName)
 	if flag {


### PR DESCRIPTION
Fixes https://github.com/open-cluster-management-io/clusteradm/issues/350

`ClusterClaim` API is still at version `cluster.open-cluster-management.io/v1alpha1`, however, the current code checks `ClusterClaim` resource in  version `cluster.open-cluster-management.io/v1` and does not find it, so it gives out an invalid error message saying that the command should be run against a managed cluster instead of an hub cluster. Using the right `apiVersion` fixes the issue.