### PR TITLE
pick newest secret while running get bootstrap token

### DIFF
--- a/pkg/cmd/get/token/exec.go
+++ b/pkg/cmd/get/token/exec.go
@@ -4,6 +4,7 @@ package token
 import (
 	"context"
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"open-cluster-management.io/clusteradm/pkg/cmd/init/scenario"

--- a/pkg/helpers/client.go
+++ b/pkg/helpers/client.go
@@ -5,6 +5,7 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -175,9 +176,15 @@ func GetBootstrapSecret(ctx context.Context, kubeClient kubernetes.Interface) (*
 	if err != nil {
 		return nil, err
 	}
+	//sort items by creationTimestamp
+	sort.Slice(l.Items, func(i, j int) bool {
+		return l.Items[j].CreationTimestamp.Before(&l.Items[i].CreationTimestamp)
+	})
+	// find newest bootstrap secret
 	for _, s := range l.Items {
 		if strings.HasPrefix(s.Name, config.BootstrapSecretPrefix) {
 			bootstrapSecret = &s
+			break
 		}
 	}
 	if bootstrapSecret == nil {


### PR DESCRIPTION
For now, if there are many bootstrap secret in `kube-system` ns, the `clusteradm get token --use-bootstrap-token` command would just fetch the last one in the list. This is not a excepted behavior because the last one is not the newest one.