### PR TITLE
Display error in CheckForHub

### DIFF
--- a/pkg/helpers/check/check.go
+++ b/pkg/helpers/check/check.go
@@ -28,7 +28,7 @@ func CheckForHub(client clusterclient.Interface) error {
 			return fmt.Errorf(msg)
 
 		}
-		return fmt.Errorf("failed to list GroupVersion: %s", clusterv1.GroupVersion.String())
+		return fmt.Errorf("failed to list GroupVersion %s: %s", clusterv1.GroupVersion.String(), err)
 
 	}
 	flag := findResource(list, ManagedClusterResourceName)


### PR DESCRIPTION
before:

````
Error: failed to list GroupVersion: cluster.open-cluster-management.io/v1
exit status 1
````

after:

````
Error: failed to list GroupVersion cluster.open-cluster-management.io/v1: Get "https://xxx.xxx.xxx.xxx/apis/cluster.open-cluster-management.io/v1": getting credentials: exec: executable gke-gcloud-auth-plugin not found

It looks like you are trying to use a client-go credential plugin that is not installed.

To learn more about this feature, consult the documentation available at:
      https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins

Install gke-gcloud-auth-plugin for kubectl by following https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin
exit status 1
````