### PR TITLE
:seedling: Remove managed cluster2 in e2e to reduce costs

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -52,7 +52,8 @@ err := e2e.Clusteradm().<Subcommand-Method>.Run()
 ### reset e2e environment
 
 #### 1. ResetEnv
-First, we define an initial e2e environment state: 1 hub, 2 managed(cluster1, cluster2), hub is initialized, cluster1 is join and accepted, cluster2 is just created.
+First, we define an initial e2e environment state: 1 hub, 1 managed cluster(cluster1), hub is initialized, cluster1 is
+joined and accepted.
 
 You need to call `ResetEnv` method to reset the e2e environment to initial state after each test senario which made a change on the test environment.
 ```go
@@ -76,10 +77,10 @@ Now we will show you how to write tests for clusteradm command.
 
 1.  First, what you need to do is: Call `e2e.ResetEnv()` in `ginkgo.AfterEach` to make sure the environment is reset to initial state after your test code have made changes to the environment,.
 
-    And if you just want an empty environment, call `e2e.ClearEnv()` in  `ginkgo.AfterEach` to make sure the applied resources are removed before youe test cases start.
+    And if you just want an empty environment, call `e2e.ClearEnv()` in  `ginkgo.AfterEach` to make sure the applied resources are removed before your test cases start.
 
 
-    *Actually, we've started the e2e environment for you, which includes 3 clusters(1 hub, 2 managed clusters). Hub is initialized and managed cluster1 is joined&accepted to hub.*
+    *Actually, we've started the e2e environment for you, which includes 2 clusters(1 hub, 1 managed cluster). Hub is initialized and managed cluster1 is joined&accepted to hub.*
 
 
 
@@ -89,7 +90,7 @@ Now we will show you how to write tests for clusteradm command.
     ```
     The command will be executed, then you just need to focus on the err. 
 
-    But if the output of a command such as `init` or `get token` needs to be reuse? 
+    But if the output of a command such as `init` or `get token` needs to be reused? 
     Don't worry, the output has been automatically resolved and stored in e2e instance. while you want to use this, just call:
     ```
     e2e.CommandResult().Token()

--- a/test/e2e/clusteradm/joinhubscenario_bootstrsptoken_test.go
+++ b/test/e2e/clusteradm/joinhubscenario_bootstrsptoken_test.go
@@ -54,25 +54,6 @@ var _ = ginkgo.Describe("test clusteradm with bootstrap token", func() {
 
 			originalToken = e2e.CommandResult().RawCommand()
 
-			ginkgo.By("managedcluster2 join hub")
-			err = e2e.Clusteradm().Join(
-				"--context", e2e.Cluster().ManagedCluster2().Context(),
-				"--hub-token", e2e.CommandResult().Token(), "--hub-apiserver", e2e.CommandResult().Host(),
-				"--cluster-name", e2e.Cluster().ManagedCluster2().Name(),
-				"--wait",
-				"--bundle-version=latest",
-				"--force-internal-endpoint-lookup",
-			)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "managedcluster2 join error")
-
-			ginkgo.By("hub accept managedcluster2")
-			err = e2e.Clusteradm().Accept(
-				"--clusters", e2e.Cluster().ManagedCluster2().Name(),
-				"--wait",
-				"--context", e2e.Cluster().Hub().Context(),
-			)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "clusteradm accept error")
-
 			ginkgo.By("delete token")
 			err = e2e.Clusteradm().Delete(
 				"token",

--- a/test/e2e/clusteradm/joinhubscenario_sa_test.go
+++ b/test/e2e/clusteradm/joinhubscenario_sa_test.go
@@ -50,25 +50,6 @@ var _ = ginkgo.Describe("test clusteradm with service account", func() {
 
 			originalToken = e2e.CommandResult().RawCommand()
 
-			ginkgo.By("managedcluster2 join hub")
-			err = e2e.Clusteradm().Join(
-				"--context", e2e.Cluster().ManagedCluster2().Context(),
-				"--hub-token", e2e.CommandResult().Token(), "--hub-apiserver", e2e.CommandResult().Host(),
-				"--cluster-name", e2e.Cluster().ManagedCluster2().Name(),
-				"--wait",
-				"--bundle-version=latest",
-				"--force-internal-endpoint-lookup",
-			)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "managedcluster2 join error")
-
-			ginkgo.By("hub accept managedcluster2")
-			err = e2e.Clusteradm().Accept(
-				"--clusters", e2e.Cluster().ManagedCluster2().Name(),
-				"--wait",
-				"--context", e2e.Cluster().Hub().Context(),
-			)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "clusteradm accept error")
-
 			ginkgo.By("delete token")
 			err = e2e.Clusteradm().Delete(
 				"token",

--- a/test/e2e/e2e-test.mk
+++ b/test/e2e/e2e-test.mk
@@ -3,23 +3,19 @@ export KUBECONFIG := ${HOME}/.kube/config
 
 export HUB_NAME := ${PROJECT_NAME}-e2e-test-hub
 export MANAGED_CLUSTER1_NAME := ${PROJECT_NAME}-e2e-test-c1
-export MANAGED_CLUSTER2_NAME := ${PROJECT_NAME}-e2e-test-c2
 
 export HUB_CTX := kind-${HUB_NAME}
 export MANAGED_CLUSTER1_CTX := kind-${MANAGED_CLUSTER1_NAME}
-export MANAGED_CLUSTER2_CTX := kind-${MANAGED_CLUSTER2_NAME}
 
 
 clean-e2e: 
 	kind delete cluster --name ${HUB_NAME}
 	kind delete cluster --name ${MANAGED_CLUSTER1_NAME}
-	kind delete cluster --name ${MANAGED_CLUSTER2_NAME}
 .PHONY: clean-e2e
 
 # start clusters and set context variables
 start-cluster: 
 	kind create cluster --name ${MANAGED_CLUSTER1_NAME}
-	kind create cluster --name ${MANAGED_CLUSTER2_NAME}
 	kind create cluster --name ${HUB_NAME} --image kindest/node:v1.24.0
 .PHONY: start-cluster 
 

--- a/test/e2e/util/e2econf.go
+++ b/test/e2e/util/e2econf.go
@@ -28,8 +28,6 @@ func NewTestE2eConfig(
 	hubctx string,
 	mcl1 string,
 	mcl1ctx string,
-	mcl2 string,
-	mcl2ctx string,
 ) *TestE2eConfig {
 
 	ctx := clusterValues{
@@ -40,10 +38,6 @@ func NewTestE2eConfig(
 		mcl1: &clusterConfig{
 			name:    mcl1,
 			context: mcl1ctx,
-		},
-		mcl2: &clusterConfig{
-			name:    mcl2,
-			context: mcl2ctx,
 		},
 	}
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -44,12 +44,7 @@ func initE2E() (*TestE2eConfig, error) {
 	if v := os.Getenv("MANAGED_CLUSTER1_CTX"); v == "" {
 		os.Setenv("MANAGED_CLUSTER1_CTX", "kind-"+os.Getenv("MANAGED_CLUSTER1_NAME"))
 	}
-	if v := os.Getenv("MANAGED_CLUSTER2_NAME"); v == "" {
-		os.Setenv("MANAGED_CLUSTER2_NAME", projectName+"-e2e-test-c2")
-	}
-	if v := os.Getenv("MANAGED_CLUSTER2_CTX"); v == "" {
-		os.Setenv("MANAGED_CLUSTER2_CTX", "kind-"+os.Getenv("MANAGED_CLUSTER2_NAME"))
-	}
+
 	if v := os.Getenv("KUBECONFIG"); v == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -62,7 +57,6 @@ func initE2E() (*TestE2eConfig, error) {
 		os.Getenv("KUBECONFIG"),
 		os.Getenv("HUB_NAME"), os.Getenv("HUB_CTX"),
 		os.Getenv("MANAGED_CLUSTER1_NAME"), os.Getenv("MANAGED_CLUSTER1_CTX"),
-		os.Getenv("MANAGED_CLUSTER2_NAME"), os.Getenv("MANAGED_CLUSTER2_CTX"),
 	)
 
 	// clearenv set the e2e environment from initial state to empty
@@ -78,20 +72,6 @@ func initE2E() (*TestE2eConfig, error) {
 			return err
 		}
 		err = WaitNamespaceDeleted(e2eConf.Kubeconfigpath, e2eConf.Cluster().ManagedCluster1().Context(), config.ManagedClusterNamespace)
-		if err != nil {
-			return err
-		}
-
-		fmt.Println("unjoin managedcluster2...")
-		err = e2eConf.Clusteradm().Unjoin(
-			"--context", e2eConf.Cluster().ManagedCluster2().Context(),
-			"--cluster-name", e2eConf.Cluster().ManagedCluster2().Name(),
-			"--purge-operator=false",
-		)
-		if err != nil {
-			return err
-		}
-		err = WaitNamespaceDeleted(e2eConf.Kubeconfigpath, e2eConf.Cluster().ManagedCluster2().Context(), config.ManagedClusterNamespace)
 		if err != nil {
 			return err
 		}
@@ -165,16 +145,6 @@ func (tec *TestE2eConfig) ResetEnv() error {
 		"--clusters", tec.Cluster().ManagedCluster1().Name(),
 		"--wait",
 		"--context", tec.Cluster().Hub().Context(),
-	)
-	if err != nil {
-		return err
-	}
-
-	// ensure managed cluster2 is not join-accepted
-	fmt.Println("ensure managed cluster2 is unjoined...")
-	err = tec.Clusteradm().Unjoin(
-		"--context", tec.Cluster().ManagedCluster2().Context(),
-		"--cluster-name", tec.Cluster().ManagedCluster2().Name(),
 	)
 	if err != nil {
 		return err

--- a/test/e2e/util/values.go
+++ b/test/e2e/util/values.go
@@ -17,7 +17,6 @@ func (cc *clusterConfig) Context() string {
 type clusterValues struct {
 	hub  *clusterConfig
 	mcl1 *clusterConfig
-	mcl2 *clusterConfig
 }
 
 func (cv *clusterValues) Hub() *clusterConfig {
@@ -26,10 +25,6 @@ func (cv *clusterValues) Hub() *clusterConfig {
 
 func (cv *clusterValues) ManagedCluster1() *clusterConfig {
 	return cv.mcl1
-}
-
-func (cv *clusterValues) ManagedCluster2() *clusterConfig {
-	return cv.mcl2
 }
 
 type values struct {


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Now we start 3 kind clusters in our e2e tests, this is resource intensive, this PR will remove the managed cluster2 in e2e test to reduce the costs.

## Related issue(s)

Fixes #
