### PR TITLE
:bug: Disable the propagator webhook; Add ClusterManagementAddon manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ check-copyright:
 	@build/check-copyright.sh
 
 .PHONY: test
-test:
+test: deps
 	@build/run-unit-tests.sh
 
 .PHONY: clean-test

--- a/pkg/cmd/create/sampleapp/suite_test.go
+++ b/pkg/cmd/create/sampleapp/suite_test.go
@@ -2,14 +2,15 @@
 package sampleapp
 
 import (
+	"path/filepath"
+	"testing"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"path/filepath"
-	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"

--- a/pkg/cmd/install/hubaddon/exec.go
+++ b/pkg/cmd/install/hubaddon/exec.go
@@ -3,9 +3,10 @@ package hubaddon
 
 import (
 	"fmt"
-	"open-cluster-management.io/clusteradm/pkg/helpers/reader"
 	"os"
 	"strings"
+
+	"open-cluster-management.io/clusteradm/pkg/helpers/reader"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"

--- a/pkg/cmd/install/hubaddon/exec.go
+++ b/pkg/cmd/install/hubaddon/exec.go
@@ -90,6 +90,7 @@ func (o *Options) runWithClient() error {
 		// Install the Application Management Addon
 		case appMgrAddonName:
 			files := []string{
+				"addon/appmgr/clustermanagementaddon_appmgr.yaml",
 				"addon/appmgr/clusterrole_agent.yaml",
 				"addon/appmgr/clusterrole_binding.yaml",
 				"addon/appmgr/clusterrole.yaml",
@@ -140,6 +141,8 @@ func (o *Options) runWithClient() error {
 				"addon/policy/propagator_role.yaml",
 				"addon/policy/propagator_rolebinding.yaml",
 				"addon/policy/propagator_serviceaccount.yaml",
+				"addon/policy/clustermanagementaddon_configpolicy.yaml",
+				"addon/policy/clustermanagementaddon_policyframework.yaml",
 				"addon/appmgr/crd_placementrule.yaml",
 			}
 

--- a/pkg/cmd/install/hubaddon/scenario/addon/appmgr/clustermanagementaddon_appmgr.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/appmgr/clustermanagementaddon_appmgr.yaml
@@ -1,0 +1,9 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: application-manager
+spec:
+  addOnMeta:
+    description: Synchronizes application on the managed clusters from the hub
+    displayName: Application Manager

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/clustermanagementaddon_configpolicy.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/clustermanagementaddon_configpolicy.yaml
@@ -1,0 +1,12 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: config-policy-controller
+spec:
+  addOnMeta:
+    description: Audits k8s resources and remediates violation based on configuration policies.
+    displayName: Config Policy Addon
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addondeploymentconfigs

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/clustermanagementaddon_policyframework.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/clustermanagementaddon_policyframework.yaml
@@ -1,0 +1,12 @@
+# Copyright Contributors to the Open Cluster Management project
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+metadata:
+  name: governance-policy-framework
+spec:
+  addOnMeta:
+    description: Distributes policies and collects policy evaluation results.
+    displayName: Governance Policy Framework Addon
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addondeploymentconfigs

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_clusterrole.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_clusterrole.yaml
@@ -41,18 +41,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create
@@ -68,6 +56,16 @@ rules:
   - secrets
   verbs:
   - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - governance-policy-database
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resourceNames:

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_deployment.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_deployment.yaml
@@ -11,6 +11,8 @@ spec:
       name: governance-policy-propagator
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: governance-policy-propagator
       labels:
         name: governance-policy-propagator
     spec:
@@ -19,6 +21,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8383
         - --leader-elect
+        - --enable-webhooks=false
         command:
         - governance-policy-propagator
         env:
@@ -30,6 +33,10 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: governance-policy-propagator
+        - name: WATCH_NAMESPACE_COMPLIANCE_EVENTS_STORE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: quay.io/open-cluster-management/governance-policy-propagator:{{ .BundleVersion.PolicyAddon }}
         imagePullPolicy: Always
         name: governance-policy-propagator

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_role.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_role.yaml
@@ -6,18 +6,6 @@ metadata:
   namespace: {{ .Namespace }}
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/pkg/cmd/install/hubaddon/suite_test.go
+++ b/pkg/cmd/install/hubaddon/suite_test.go
@@ -2,13 +2,15 @@
 package hubaddon
 
 import (
+	"path/filepath"
+	"testing"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -41,7 +43,11 @@ var _ = ginkgo.BeforeSuite(func() {
 	ginkgo.By("bootstrapping test environment")
 
 	// start a kube-apiserver
-	testEnv = &envtest.Environment{}
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "..", "vendor", "open-cluster-management.io", "api", "addon", "v1alpha1"),
+		},
+	}
 
 	cfg, err := testEnv.Start()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

A GRC webhook was added, but it requires cert-manager as a prerequisite. Until we can resolve/update that, leave it disabled by default.

Also, there was a check added for ClusterManagementAddon, which were not deployed originally, currently causing an error during enabling app and policy addons:
https://github.com/open-cluster-management-io/clusteradm/blob/ed1069349e4f05faea934863035acedd690bbb2c/pkg/cmd/addon/enable/exec.go#L110-L114

/cc @mprahl @yiraeChristineKim @mikeshng @qiujian16 @ycyaoxdu @yue9944882