### PR TITLE
🐛 Filter manifest works by name

### DIFF
--- a/pkg/cmd/get/work/exec.go
+++ b/pkg/cmd/get/work/exec.go
@@ -71,7 +71,7 @@ func (o *Options) run() (err error) {
 		if len(o.workName) > 0 {
 			listOpts.FieldSelector = fmt.Sprintf("metadata.name=%s", o.workName)
 		}
-		works, err := workClient.WorkV1().ManifestWorks(cluster).List(context.TODO(), metav1.ListOptions{})
+		works, err := workClient.WorkV1().ManifestWorks(cluster).List(context.TODO(), listOpts)
 		if err != nil {
 			return err
 		}
@@ -88,13 +88,12 @@ func (o *Options) convertToTree(obj runtime.Object, tree *printer.TreePrinter) *
 		for _, work := range workList.Items {
 			cluster, number, applied, available := getFileds(work)
 			mp := make(map[string]interface{})
-			mp[".Cluster"] = cluster
 			mp[".Number of Manifests"] = number
 			mp[".Applied"] = applied
 			mp[".Available"] = available
-			tree.AddFileds(work.Name, &mp)
+			tree.AddFileds(fmt.Sprintf("%s.%s", cluster, work.Name), &mp)
 			workStatus := printer.WorkDetails(".Resources", &work)
-			tree.AddFileds(work.Name, &workStatus)
+			tree.AddFileds(fmt.Sprintf("%s.%s", cluster, work.Name), &workStatus)
 		}
 	}
 	return tree


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
- filter manifestwork by name when listing manifestworks
- add a layer of cluster hierarchy to prevent manifestwork with the same name in different clusters from being filtered

example output:
```
╰─# clusteradm get works my-work --clusters=kind,local-cluster
<ManifestWork> 
└── <local-cluster> 
│   ├── <my-work> 
│       └── <Number of Manifests> 1
│       └── <Applied> True
│       └── <Available> True
│       └── <Resources> 
│           └── <configmaps> 
│               └── <default/test-cm> applied
└── <kind> 
    └── <my-work> 
        └── <Available> 
        └── <Number of Manifests> 1
        └── <Applied> 
```

## Related issue(s)

Fixes #https://github.com/open-cluster-management-io/ocm/issues/425
