### PR TITLE
✨ Check if there any managed clusters exists before hub cleanup

### DIFF
--- a/pkg/cmd/clean/exec.go
+++ b/pkg/cmd/clean/exec.go
@@ -224,8 +224,12 @@ func isManagedClusterExist(config *rest.Config) (bool, error) {
 		return false, err
 	}
 
-	if len(managedClusters.Items) > 0 {
-		return true, nil
+	for _, cluster := range managedClusters.Items {
+		for _, cond := range cluster.Status.Conditions {
+			if cond.Type == "ManagedClusterConditionAvailable" && cond.Status == "True" {
+				return true, nil
+			}
+		}
 	}
 	return false, nil
 }

--- a/pkg/cmd/clean/exec.go
+++ b/pkg/cmd/clean/exec.go
@@ -72,7 +72,7 @@ func (o *Options) Run() error {
 	}
 
 	if exist {
-		fmt.Fprintf(o.Streams.Out, "Please detach the managed clusters from the hub control plane\n")
+		fmt.Fprintf(o.Streams.Out, "Please detach all managed clusters from the hub control plane\n")
 		return nil
 	}
 

--- a/pkg/cmd/clean/exec.go
+++ b/pkg/cmd/clean/exec.go
@@ -5,9 +5,11 @@ package init
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/rest"
 	"log"
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	clusterapiv1 "open-cluster-management.io/api/cluster/v1"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -225,10 +227,8 @@ func isManagedClusterExist(config *rest.Config) (bool, error) {
 	}
 
 	for _, cluster := range managedClusters.Items {
-		for _, cond := range cluster.Status.Conditions {
-			if cond.Type == "ManagedClusterConditionAvailable" && cond.Status == "True" {
-				return true, nil
-			}
+		if meta.IsStatusConditionTrue(cluster.Status.Conditions, clusterapiv1.ManagedClusterConditionAvailable) {
+			return true, nil
 		}
 	}
 	return false, nil

--- a/test/e2e/util/helper.go
+++ b/test/e2e/util/helper.go
@@ -4,6 +4,8 @@ package util
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/meta"
+	clusterapiv1 "open-cluster-management.io/api/cluster/v1"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -49,10 +51,9 @@ func WaitForManagedClusterAvailableStatusToChange(restcfg *rest.Config, clusterN
 		if err != nil {
 			return false, err
 		}
-		for _, cond := range managedCluster.Status.Conditions {
-			if cond.Type == "ManagedClusterConditionAvailable" && cond.Status != "True" {
-				return true, nil
-			}
+
+		if !meta.IsStatusConditionTrue(managedCluster.Status.Conditions, clusterapiv1.ManagedClusterConditionAvailable) {
+			return true, nil
 		}
 
 		return false, nil

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -84,6 +84,12 @@ func initE2E() (*TestE2eConfig, error) {
 		if err != nil {
 			return err
 		}
+
+		// wait for managed cluster Available status to be "False"
+		err = WaitForManagedClusterAvailableStatusToChange(e2eConf.Cluster().Hub().KubeConfig(), e2eConf.Cluster().ManagedCluster1().Name())
+		if err != nil {
+			return err
+		}
 		err = e2eConf.Clusteradm().Clean(
 			"--context", e2eConf.Cluster().Hub().Context(),
 			"--purge-operator=false",


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
If any managed clusters exist, `clusteradm clean` hangs for some time and then returns 'cluster manager still exists'. Therefore, we should check if any managed clusters exist before waiting for the hub cleanup and return the proper message.

## Related issue(s)

Fixes #
