### PR TITLE
🐛 fix feature gate merges in ConvertToFeatureGateAPI

### DIFF
--- a/pkg/genericclioptions/feature_gates_test.go
+++ b/pkg/genericclioptions/feature_gates_test.go
@@ -1,0 +1,93 @@
+// Copyright Contributors to the Open Cluster Management project
+package genericclioptions
+
+import (
+	"slices"
+	"testing"
+
+	"k8s.io/component-base/featuregate"
+	ocmfeature "open-cluster-management.io/api/feature"
+	operatorv1 "open-cluster-management.io/api/operator/v1"
+)
+
+func TestConvertToFeatureGateAPI(t *testing.T) {
+	tests := []struct {
+		name               string
+		featureGates       func() featuregate.MutableFeatureGate
+		defaultFeatureGate map[featuregate.Feature]featuregate.FeatureSpec
+		expected           []operatorv1.FeatureGate
+	}{
+		{
+			name: "disable default feature gate",
+			featureGates: func() featuregate.MutableFeatureGate {
+				fg := featuregate.NewFeatureGate()
+				_ = fg.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+					"AddonManagement": {Default: false},
+				})
+				return fg
+			},
+			defaultFeatureGate: ocmfeature.DefaultHubAddonManagerFeatureGates,
+			expected:           []operatorv1.FeatureGate{},
+		},
+		{
+			name: "enable default feature gate",
+			featureGates: func() featuregate.MutableFeatureGate {
+				fg := featuregate.NewFeatureGate()
+				_ = fg.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+					"AddonManagement": {Default: true},
+				})
+				return fg
+			},
+			defaultFeatureGate: ocmfeature.DefaultHubAddonManagerFeatureGates,
+			expected: []operatorv1.FeatureGate{
+				{Feature: "AddonManagement", Mode: operatorv1.FeatureGateModeTypeEnable},
+			},
+		},
+		{
+			name: "enable non-default feature gate",
+			featureGates: func() featuregate.MutableFeatureGate {
+				fg := featuregate.NewFeatureGate()
+				_ = fg.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+					"ManifestWorkReplicaSet": {Default: true},
+				})
+				return fg
+			},
+			defaultFeatureGate: ocmfeature.DefaultHubWorkFeatureGates,
+			expected: []operatorv1.FeatureGate{
+				{Feature: "ManifestWorkReplicaSet", Mode: operatorv1.FeatureGateModeTypeEnable},
+			},
+		},
+		{
+			name: "enable non-default feature gate, ensure default feature gates remain enabled",
+			featureGates: func() featuregate.MutableFeatureGate {
+				fg := featuregate.NewFeatureGate()
+				_ = fg.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+					"MultipleHubs": {Default: true},
+				})
+				return fg
+			},
+			defaultFeatureGate: ocmfeature.DefaultSpokeRegistrationFeatureGates,
+			expected: []operatorv1.FeatureGate{
+				{Feature: "AddonManagement", Mode: operatorv1.FeatureGateModeTypeEnable},
+				{Feature: "ClusterClaim", Mode: operatorv1.FeatureGateModeTypeEnable},
+				{Feature: "MultipleHubs", Mode: operatorv1.FeatureGateModeTypeEnable},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ConvertToFeatureGateAPI(tt.featureGates(), tt.defaultFeatureGate)
+			slices.SortFunc(actual, func(i, j operatorv1.FeatureGate) int {
+				if i.Feature < j.Feature {
+					return -1
+				} else if i.Feature > j.Feature {
+					return 1
+				}
+				return 0
+			})
+			if !slices.Equal(actual, tt.expected) {
+				t.Errorf("expected %v, got %v", tt.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

## Summary

Prior to this PR, ConvertToFeatureGateAPI was incorrectly merging feature gates specified via the `--feature-gates` command line flag with the default feature flag sets.
- When users specifically enable a feature that's enabled by default, the feature is dropped
- When users enable a feature gate that that's disabled by default, all enabled-by-default features are dropped

The unit tests added in this PR fail against main as follows:
```shell
Running tool: /opt/homebrew/bin/go test -timeout 30s -run ^TestConvertToFeatureGateAPI$ open-cluster-management.io/clusteradm/pkg/genericclioptions -v

=== RUN   TestConvertToFeatureGateAPI
=== RUN   TestConvertToFeatureGateAPI/disable_default_feature_gate
    /Users/tylergillson/spectrocloud/repos/oss/ocm/clusteradm/pkg/genericclioptions/feature_gates_test.go:89: expected [], got [{AddonManagement Disable}]
=== RUN   TestConvertToFeatureGateAPI/enable_default_feature_gate
    /Users/tylergillson/spectrocloud/repos/oss/ocm/clusteradm/pkg/genericclioptions/feature_gates_test.go:89: expected [{AddonManagement Enable}], got []
=== RUN   TestConvertToFeatureGateAPI/enable_non-default_feature_gate
=== RUN   TestConvertToFeatureGateAPI/enable_non-default_feature_gate,_ensure_default_feature_gates_remain_enabled
    /Users/tylergillson/spectrocloud/repos/oss/ocm/clusteradm/pkg/genericclioptions/feature_gates_test.go:89: expected [{AddonManagement Enable} {ClusterClaim Enable} {MultipleHubs Enable}], got [{MultipleHubs Enable}]
--- FAIL: TestConvertToFeatureGateAPI (0.00s)
    --- FAIL: TestConvertToFeatureGateAPI/disable_default_feature_gate (0.00s)
    --- FAIL: TestConvertToFeatureGateAPI/enable_default_feature_gate (0.00s)
    --- PASS: TestConvertToFeatureGateAPI/enable_non-default_feature_gate (0.00s)
    --- FAIL: TestConvertToFeatureGateAPI/enable_non-default_feature_gate,_ensure_default_feature_gates_remain_enabled (0.00s)
FAIL
FAIL	open-cluster-management.io/clusteradm/pkg/genericclioptions	0.730s
```

Now all flags are enabled, whether user-specified or enabled-by-default. Any disabled flags are simply not specified.

However, the original intention of the ConvertToFeatureGateAPI was unclear. Perhaps users should have to manually specify all desired flags instead of merging the two sets?

## Related issue(s)

Fixes #
