### PR TITLE
🐛 Fix `single-use dialer already dialed` issue

### DIFF
--- a/pkg/cmd/proxy/health/exec.go
+++ b/pkg/cmd/proxy/health/exec.go
@@ -152,7 +152,8 @@ func (o *Options) run(streams genericiooptions.IOStreams) error {
 	w := newWriter(streams)
 	for _, cluster := range managedClusterList.Items {
 		if probingClusters.Len() == 0 || probingClusters.Has(cluster.Name) {
-			tunnel, err := konnectivity.CreateSingleUseGrpcTunnel(
+			tunnel, err := konnectivity.CreateSingleUseGrpcTunnelWithContext(
+				context.TODO(),
 				ctx,
 				net.JoinHostPort(o.proxyServerHost, strconv.Itoa(o.proxyServerPort)),
 				grpc.WithTransportCredentials(grpccredentials.NewTLS(tlsCfg)),

--- a/pkg/cmd/proxy/health/exec.go
+++ b/pkg/cmd/proxy/health/exec.go
@@ -148,19 +148,19 @@ func (o *Options) run(streams genericiooptions.IOStreams) error {
 		return errors.Wrapf(err, "failed building tls config")
 	}
 
-	tunnel, err := konnectivity.CreateSingleUseGrpcTunnel(
-		ctx,
-		net.JoinHostPort(o.proxyServerHost, strconv.Itoa(o.proxyServerPort)),
-		grpc.WithTransportCredentials(grpccredentials.NewTLS(tlsCfg)),
-	)
-	if err != nil {
-		return errors.Wrapf(err, "failed starting konnectivity proxy")
-	}
-
 	probingClusters := o.ClusterOption.AllClusters()
 	w := newWriter(streams)
 	for _, cluster := range managedClusterList.Items {
 		if probingClusters.Len() == 0 || probingClusters.Has(cluster.Name) {
+			tunnel, err := konnectivity.CreateSingleUseGrpcTunnel(
+				ctx,
+				net.JoinHostPort(o.proxyServerHost, strconv.Itoa(o.proxyServerPort)),
+				grpc.WithTransportCredentials(grpccredentials.NewTLS(tlsCfg)),
+			)
+			if err != nil {
+				return errors.Wrapf(err, "failed starting konnectivity proxy")
+			}
+
 			if err := o.visit(&w, hubRestConfig, addonClient, tunnel.DialContext, cluster.Name); err != nil {
 				klog.Errorf("An error occurred when requesting: %v", err)
 			}


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Before:

```
$ clusteradm proxy health
I1102 11:57:52.678047   38144 portforward.go:154] Forwarding to pod cluster-proxy-696b948dff-bmlhx
E1102 11:57:53.647755   38144 exec.go:278] Failed requesting /healthz endpoint for cluster default: No agent available
I1102 11:57:53.754295   38144 portforward.go:249] Connection closed due to error stream closed
E1102 11:57:53.755129   38144 exec.go:278] Failed requesting /healthz endpoint for cluster global: single-use dialer already dialed
E1102 11:57:53.858835   38144 exec.go:278] Failed requesting /healthz endpoint for cluster spoke2: single-use dialer already dialed
```

After:
```
clusteradm proxy health
I1105 13:49:17.028443   16533 portforward.go:154] Forwarding to pod cluster-proxy-696b948dff-zqfw8
I1105 13:49:18.541635   16533 portforward.go:154] Forwarding to pod cluster-proxy-696b948dff-zqfw8
CLUSTER NAME    INSTALLED    AVAILABLE    PROBED HEALTH    LATENCY
rakib           True         True         True             598.983698ms
spoke1          True         True         False            <none>
```

## Related issue(s)

Fixes #
