### PR TITLE
:sparkles: feat: add `--managed-cluster-arn` flag to the `clusteradm join` command

### DIFF
--- a/pkg/cmd/join/cmd.go
+++ b/pkg/cmd/join/cmd.go
@@ -83,6 +83,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	cmd.Flags().Int32Var(&o.clientCertExpirationSeconds, "client-cert-expiration-seconds", 31536000, "clientCertExpirationSeconds represents the seconds of a client certificate to expire.")
 	cmd.Flags().StringVar(&o.registrationAuth, "registration-auth", "", "The type of authentication to use for registering and authenticating with hub")
 	cmd.Flags().StringVar(&o.hubClusterArn, "hub-cluster-arn", "", "The arn of the hub cluster(i.e. EKS cluster) to which managed-cluster will join")
+	cmd.Flags().StringVar(&o.managedClusterArn, "managed-cluster-arn", "", "The arn of the managed cluster(i.e. EKS cluster) which will be joining the hub")
 	cmd.Flags().StringArrayVar(&o.klusterletAnnotations, "klusterlet-annotation", []string{}, fmt.Sprintf("Annotations to set on the ManagedCluster, in key=value format. Note: each key will be automatically prefixed with '%s/', if not set.", operatorv1.ClusterAnnotationsKeyPrefix))
 	return cmd
 }

--- a/pkg/cmd/join/options.go
+++ b/pkg/cmd/join/options.go
@@ -93,6 +93,9 @@ type Options struct {
 	// The arn of hub cluster(i.e. EKS) to which managed-cluster will join
 	hubClusterArn string
 
+	// The arn of managed cluster(i.e. EKS) which will be joining the hub
+	managedClusterArn string
+
 	// Annotations for registration controller to set on the ManagedCluster
 	klusterletAnnotations []string
 }


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR introduces a new `--managed-cluster-arn` flag to `clusteradm join`. This allows users to specify the managed clusters ARN in the case that their kubeconfig doesn't have it configured.

#### Before change
There was no way to pass in the managed cluster arn, so running `clusteradm join` on a spoke cluster without it's name being set to it's arn yielded the following results:
```bash
clusteradm join --hub-token $TOKEN --hub-apiserver $HUB_API_SERVER \
--wait --cluster-name $SPOKE_CLUSTER_NAME --singleton \
--bundle-version latest --registration-auth awsirsa \
--hub-cluster-arn arn:aws:eks:$HUB_REGION:"$HUB_ACCOUNT_ID":cluster/$HUB_CLUSTER_NAME
Preflight check: HubKubeconfig check Passed with 0 warnings and 0 errors
Preflight check: DeployMode Check Passed with 0 warnings and 0 errors
Preflight check: ClusterName Check Passed with 0 warnings and 0 errors
CRD successfully registered.
Error: error when creating "local": Klusterlet.operator.open-cluster-management.io "klusterlet" is invalid: spec.registrationConfiguration.registrationDriver.awsIrsa.managedClusterArn: Invalid value: "hub-eks-test.us-west-2.eksctl.io": spec.registrationConfiguration.registrationDriver.awsIrsa.managedClusterArn in body should match '^arn:aws:eks:([a-zA-Z0-9-]+):(\d{12}):cluster/([a-zA-Z0-9-]+)$'
```

#### After change
Pass in the `--managed-cluster-arn` flag and see the join command run succesfully
```bash
clusteradm join --hub-token $TOKEN --hub-apiserver $HUB_API_SERVER \
--wait --cluster-name $SPOKE_CLUSTER_NAME --singleton \
--bundle-version latest --registration-auth awsirsa \
--hub-cluster-arn arn:aws:eks:$HUB_REGION:"$HUB_ACCOUNT_ID":cluster/$HUB_CLUSTER_NAME \
--managed-cluster-arn arn:aws:eks:$SPOKE_REGION:"$SPOKE_ACCOUNT_ID":cluster/$SPOKE_CLUSTER_NAME
W0515 17:19:10.707271   13904 exec.go:235] Failed looking for cluster endpoint for the registering klusterlet: configmaps "cluster-info" not found
Preflight check: HubKubeconfig check Passed with 0 warnings and 0 errors
Preflight check: DeployMode Check Passed with 0 warnings and 0 errors
Preflight check: ClusterName Check Passed with 0 warnings and 0 errors
CRD successfully registered.
Klusterlet is now available.
Managed cluster is created.
Please log onto the hub cluster and run the following command:

    clusteradm accept --clusters spoke-eks-test

This is not needed when the ManagedClusterAutoApproval feature is enabled
```

## Related issue(s)
https://github.com/open-cluster-management-io/clusteradm/issues/485