### PR TITLE
:bug: fix: create argocd appset failing with nil pointer

### DIFF
--- a/pkg/cmd/create/sampleapp/exec.go
+++ b/pkg/cmd/create/sampleapp/exec.go
@@ -3,11 +3,7 @@
 package sampleapp
 
 import (
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"runtime"
 
 	"open-cluster-management.io/clusteradm/pkg/helpers/reader"
 
@@ -75,32 +71,5 @@ func (o *Options) deployApp() error {
 	// Prepare deployment tools
 	r := reader.NewResourceReader(o.ClusteradmFlags.KubectlFactory, o.ClusteradmFlags.DryRun, o.Streams)
 
-	// Retrieve sample application manifests
-	_, currentFilePath, _, ok := runtime.Caller(0)
-	if !ok {
-		return errors.New("Error retrieving current file path")
-	}
-	appDir := filepath.Join(filepath.Dir(currentFilePath), pathToAppManifests)
-	files, err := filePathWalkDir(appDir)
-	if err != nil {
-		return err
-	}
-
-	// Apply manifests
-	return r.Apply(scenario.Files, o, files...)
-}
-
-func filePathWalkDir(root string) ([]string, error) {
-	var files []string
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if !info.IsDir() {
-			relPath, err := filepath.Rel(filepath.Dir(root), path)
-			if err != nil {
-				return err
-			}
-			files = append(files, relPath)
-		}
-		return nil
-	})
-	return files, err
+	return r.Apply(scenario.Files, o, scenario.SampleAppFiles...)
 }

--- a/pkg/cmd/create/sampleapp/scenario/resources.go
+++ b/pkg/cmd/create/sampleapp/scenario/resources.go
@@ -7,3 +7,9 @@ import (
 
 //go:embed sampleapp
 var Files embed.FS
+
+var (
+	SampleAppFiles = []string{
+		"sampleapp/appset.yaml",
+	}
+)


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Simplify create sample app logic and fix the nilpointer

```
$ clusteradm create sampleapp sample-appset
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x200192f]

goroutine 1 [running]:
open-cluster-management.io/clusteradm/pkg/cmd/create/sampleapp.filePathWalkDir.func1({0xc0006746c0, 0x53}, {0x0?, 0x0?}, {0x53?, 0x0?})
	/home/runner/work/clusteradm/clusteradm/pkg/cmd/create/sampleapp/exec.go:96 +0x2f
path/filepath.Walk({0xc0006746c0, 0x53}, 0xc000b87a28)
	/opt/hostedtoolcache/go/1.23.9/x64/src/path/filepath/path.go:425 +0x4a
open-cluster-management.io/clusteradm/pkg/cmd/create/sampleapp.filePathWalkDir({0xc0006746c0?, 0xc000294f00?})
	/home/runner/work/clusteradm/clusteradm/pkg/cmd/create/sampleapp/exec.go:95 +0x52
open-cluster-management.io/clusteradm/pkg/cmd/create/sampleapp.(*Options).deployApp(0xc000633140)
	/home/runner/work/clusteradm/clusteradm/pkg/cmd/create/sampleapp/exec.go:84 +0xea
open-cluster-management.io/clusteradm/pkg/cmd/create/sampleapp.(*Options).runWithClient(...)
	/home/runner/work/clusteradm/clusteradm/pkg/cmd/create/sampleapp/exec.go:66
open-cluster-management.io/clusteradm/pkg/cmd/create/sampleapp.(*Options).Run(0xc000633140)
	/home/runner/work/clusteradm/clusteradm/pkg/cmd/create/sampleapp/exec.go:60 +0x45
open-cluster-management.io/clusteradm/pkg/cmd/create/sampleapp.NewCmd.func2(0xc0006a6600?, {0xc000b92800?, 0x4?, 0x2a33e7f?})
	/home/runner/work/clusteradm/clusteradm/pkg/cmd/create/sampleapp/cmd.go:42 +0x5d
github.com/spf13/cobra.(*Command).execute(0xc0006a8908, {0xc000b927c0, 0x1, 0x1})
	/home/runner/work/clusteradm/clusteradm/vendor/github.com/spf13/cobra/command.go:985 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0xc000afbb08)
	/home/runner/work/clusteradm/clusteradm/vendor/github.com/spf13/cobra/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/work/clusteradm/clusteradm/vendor/github.com/spf13/cobra/command.go:1041
main.main()
	/home/runner/work/clusteradm/clusteradm/cmd/clusteradm/clusteradm.go:131 +0xc25

```

## Related issue(s)

Fixes #
