### PR TITLE
✨Feature: add enable sync label clusteradm init

### DIFF
--- a/pkg/cmd/init/cmd.go
+++ b/pkg/cmd/init/cmd.go
@@ -99,5 +99,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 		"The users or identities that can be auto approved for CSR and auto accepted to join with hub cluster")
 	cmd.Flags().StringSliceVar(&o.autoApprovedARNPatterns, "auto-approved-arn-patterns", []string{},
 		"List of AWS EKS ARN patterns so any EKS clusters with these patterns will be auto accepted to join with hub cluster")
+	cmd.Flags().BoolVar(&o.enableSyncLabels, "enable-sync-labels", false, "If true, sync the labels from clustermanager to all hub resources.")
+
 	return cmd
 }

--- a/pkg/cmd/init/exec.go
+++ b/pkg/cmd/init/exec.go
@@ -64,6 +64,8 @@ func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
+	o.clusterManagerChartConfig.EnableSyncLabels = o.enableSyncLabels
+
 	if !o.singleton {
 		o.clusterManagerChartConfig.Images = chart.ImagesConfig{
 			Registry: o.registry,

--- a/pkg/cmd/init/options.go
+++ b/pkg/cmd/init/options.go
@@ -65,6 +65,8 @@ type Options struct {
 	autoApprovedARNPatterns []string
 	// List of tags to be added to AWS resources created by hub while processing awsirsa registration request
 	awsResourceTags []string
+	// enableSyncLabels is to enable the feature which can sync the labels from clustermanager to all hub resources.
+	enableSyncLabels bool
 }
 
 func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, streams genericiooptions.IOStreams) *Options {


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Adding --enable-sync-labels flag to clusteradm init as part of change done on [ocm](https://github.com/open-cluster-management-io/ocm/commit/215cfed77e52b13e1b409d6d03866669ef77bc57)

## Related issue(s)

https://github.com/open-cluster-management-io/ocm/issues/957

Fixes # https://github.com/open-cluster-management-io/ocm/issues/957
