### PR TITLE
✨ support target architecture for `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -194,7 +194,9 @@ checkHttpRequestCLI
 if [ -z "$1" ]; then
     TARGET_VERSION="latest"
 else
-    if [[ "$1" =~ ^v.* ]]; then
+    if [ "$1" = "latest" ]; then
+        TARGET_VERSION="latest"
+    elif [[ "$1" =~ ^v.* ]]; then
         TARGET_VERSION="$1"
     else
         TARGET_VERSION="v$1"

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,9 @@
 # sudo is required to copy binary to INSTALL_DIR for linux
 : "${USE_SUDO:=false}"
 
+# Target architecture (optional, defaults to auto-detect)
+: "${ARCH:=}"
+
 # Http request CLI
 HTTP_REQUEST_CLI=curl
 
@@ -20,7 +23,9 @@ CLI_FILENAME=clusteradm
 CLI_FILE="${INSTALL_DIR}/${CLI_FILENAME}"
 
 getSystemInfo() {
-    ARCH=$(uname -m)
+    if [ -z "$ARCH" ]; then
+        ARCH=$(uname -m)
+    fi
     case $ARCH in
         armv7*) ARCH="arm";;
         aarch64) ARCH="arm64";;
@@ -37,16 +42,16 @@ getSystemInfo() {
 
 verifySupported() {
     local supported=(darwin-amd64 darwin-arm64 linux-amd64 linux-arm64 windows-amd64)
-    local current_osarch="${OS}-${ARCH}"
+    local target_osarch="${OS}-${ARCH}"
 
     for osarch in "${supported[@]}"; do
-        if [ "$osarch" == "$current_osarch" ]; then
-            echo "Your system is ${OS}_${ARCH}"
+        if [ "$osarch" == "$target_osarch" ]; then
+            echo "Installing clusteradm for ${OS}_${ARCH}"
             return
         fi
     done
 
-    echo "No prebuilt binary for ${current_osarch}"
+    echo "No prebuilt binary for ${target_osarch}"
     exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,11 @@
-# Copyright Contributors to the Open Cluster Management project
 #!/usr/bin/env bash
+# Copyright Contributors to the Open Cluster Management project
 
 # Clusteradm CLI location
-: ${INSTALL_DIR:="/usr/local/bin"}
+: "${INSTALL_DIR:=/usr/local/bin}"
 
 # sudo is required to copy binary to INSTALL_DIR for linux
-: ${USE_SUDO:="false"}
+: "${USE_SUDO:=false}"
 
 # Http request CLI
 HTTP_REQUEST_CLI=curl
@@ -27,7 +27,7 @@ getSystemInfo() {
         x86_64) ARCH="amd64";;
     esac
 
-    OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+    OS=$(uname | tr '[:upper:]' '[:lower:]')
 
     # Most linux distro needs root permission to copy the file to /usr/local/bin
     if [[ "$OS" == "linux" || "$OS" == "darwin" ]] && [ "$INSTALL_DIR" == "/usr/local/bin" ]; then
@@ -73,7 +73,7 @@ checkExisting() {
 runAsRoot() {
     local CMD="$*"
 
-    if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
+    if [ "$EUID" -ne 0 ] && [ "$USE_SUDO" = "true" ]; then
         CMD="sudo $CMD"
     fi
 
@@ -139,7 +139,7 @@ installFile() {
         exit 1
     fi
 
-    chmod o+x $tmp_root_cli
+    chmod o+x "$tmp_root_cli"
     runAsRoot cp "$tmp_root_cli" "$INSTALL_DIR"
 
     if [ -f "$CLI_FILE" ]; then
@@ -189,7 +189,7 @@ checkExisting
 
 echo "Installing $TARGET_VERSION OCM clusteradm CLI..."
 
-downloadFile $TARGET_VERSION
+downloadFile "$TARGET_VERSION"
 installFile
 cleanup
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 # Copyright Contributors to the Open Cluster Management project
+#
+# Usage: ./install.sh [version]
+#
+# If no version is provided, the latest version will be installed.
+# If a version is provided, it will be installed.
+#
+# Example: ./install.sh v0.1.0
+# Example: ./install.sh latest
 
 # Clusteradm CLI location
 : "${INSTALL_DIR:=/usr/local/bin}"
@@ -186,7 +194,11 @@ checkHttpRequestCLI
 if [ -z "$1" ]; then
     TARGET_VERSION="latest"
 else
-    TARGET_VERSION=v$1
+    if [[ "$1" =~ ^v.* ]]; then
+        TARGET_VERSION="$1"
+    else
+        TARGET_VERSION="v$1"
+    fi
 fi
 
 verifySupported


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

- Update `install.sh` to support installing `clusteradm` for a specific target architecture.
- Resolve all [shellcheck](https://github.com/koalaman/shellcheck) lints in the install script and add usage
- Make addition of `v` prefix for target version more robust

## Related Issues

The linux/arm64 build for the fleetconfig-controller [Dockerfile](https://github.com/open-cluster-management-io/lab/blob/main/fleetconfig-controller/build/Dockerfile.base#L38) leverages this script and is currently installing the incorrect (linux/amd64) binary unless `make images` is invoked from a linux/arm64 github runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added usage instructions and examples at the top of the installation script.

* **Bug Fixes**
  * Improved handling of environment variables and input parsing for greater robustness.
  * Fixed issues with command safety, including proper quoting of file paths and corrected conditional checks.

* **New Features**
  * Introduced an optional environment variable to override the target architecture during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->