### PR TITLE
📖 clean up addon cmd examples

### DIFF
--- a/pkg/cmd/addon/disable/cmd.go
+++ b/pkg/cmd/addon/disable/cmd.go
@@ -12,28 +12,22 @@ import (
 )
 
 var example = `
-# Disable argocd addon on specified clusters
+# Disable argocd addon on specified cluster
+%[1]s addon disable --names argocd --cluster cluster1
+# Disable argocd addon on multiple clusters
 %[1]s addon disable --names argocd --clusters cluster1,cluster2
-# Disable argocd addon on all clusters
-%[1]s addon disable --names argocd --all-clusters
-# Disable argocd addon to the given managed clusters in the specified namespace
-%[1]s addon disable --names argocd --namespace <namespace> --clusters <cluster1>
 
 ## Policy Framework
 
-# Disable governance-policy-framework addon on specified clusters
+# Disable governance-policy-framework addon on specified cluster
+%[1]s addon disable --names governance-policy-framework --cluster cluster1
+# Disable governance-policy-framework addon on multiple clusters
 %[1]s addon disable --names governance-policy-framework --clusters cluster1,cluster2
-# Disable governance-policy-framework addon on all clusters
-%[1]s addon disable --names governance-policy-framework --all-clusters
-# Disable governance-policy-framework addon to the given managed clusters in the specified namespace
-%[1]s addon disable --names governance-policy-framework --namespace <namespace> --clusters <cluster1>
 
-# Disable config-policy-controller addon on specified clusters
+# Disable config-policy-controller addon on specified cluster
+%[1]s addon disable --names config-policy-controller --cluster cluster1
+# Disable config-policy-controller addon on multiple clusters
 %[1]s addon disable --names config-policy-controller --clusters cluster1,cluster2
-# Disable config-policy-controller addon on all clusters
-%[1]s addon disable --names config-policy-controller --all-clusters
-# Disable config-policy-controller addon to the given managed clusters in the specified namespace
-%[1]s addon disable --names config-policy-controller --namespace <namespace> --clusters <cluster1>
 `
 
 // NewCmd...

--- a/pkg/cmd/uninstall/hubaddon/exec.go
+++ b/pkg/cmd/uninstall/hubaddon/exec.go
@@ -136,7 +136,7 @@ func (o *Options) checkExistingAddon(name string) error {
 		for _, addon := range addons.Items {
 			enabledClusters = append(enabledClusters, addon.Namespace)
 		}
-		return fmt.Errorf("there are still addons for %s enabled on some clusters, run `cluster addon disable --names %s "+
+		return fmt.Errorf("there are still addons for %s enabled on some clusters, run `clusteradm addon disable --names %s "+
 			"--clusters %s` to disable addons", name, name, strings.Join(enabledClusters, ","))
 	}
 	return nil


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

`clusteradm addon disable --help` shows examples of 2 flags `--namespace` and `--all-clusters` which are not supported.

This PR:
- removes the examples showing the unimplemented flags for `clusteradm addon disable`
- fixes a small typo in a `clusteradm uninstall hub-addon` error hint.

## Related issue(s)

Partially fixes #498 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example usage text for disabling addons to improve clarity and accuracy, including new examples for single and multiple clusters.
  * Corrected an error message to display the accurate command name for disabling addons.

No changes were made to command behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->