### PR TITLE
✨ allow labeling resources created during addon create and enable

### DIFF
--- a/pkg/cmd/addon/create/cmd.go
+++ b/pkg/cmd/addon/create/cmd.go
@@ -51,6 +51,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	cmd.Flags().BoolVar(&o.EnableHubRegistration, "hub-registration", false, "Enable the agent to register to the hub cluster")
 	cmd.Flags().StringVar(&o.ClusterRoleBindingRef, "cluster-role-bind", "", "The rolebinding to the clusterrole in "+
 		"the cluster namespace for the addon agent")
+	cmd.Flags().StringSliceVar(&o.Labels, "labels", []string{}, "Labels to add to the ClusterManagementAddOn and AddOnTemplate resources (eg. key1=value1,key2=value2)")
 	o.FileNameFlags.AddFlags(cmd.Flags())
 
 	return cmd

--- a/pkg/cmd/addon/create/exec.go
+++ b/pkg/cmd/addon/create/exec.go
@@ -4,7 +4,6 @@ package create
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -14,6 +13,8 @@ import (
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonclientset "open-cluster-management.io/api/client/addon/clientset/versioned"
 	workapiv1 "open-cluster-management.io/api/work/v1"
+
+	"open-cluster-management.io/clusteradm/pkg/helpers/parse"
 )
 
 func newAddonTemplate(o *Options) (*addonv1alpha1.AddOnTemplate, error) {
@@ -246,13 +247,5 @@ func (o *Options) readManifests() ([]workapiv1.Manifest, error) {
 
 // parseLabels parses the labels flag and returns a map of labels
 func (o *Options) parseLabels() (map[string]string, error) {
-	labelMap := make(map[string]string)
-	for _, labelString := range o.Labels {
-		labelSlice := strings.Split(labelString, "=")
-		if len(labelSlice) != 2 {
-			return nil, fmt.Errorf("error parsing label '%s'. Expected to be of the form: key=value", labelString)
-		}
-		labelMap[labelSlice[0]] = labelSlice[1]
-	}
-	return labelMap, nil
+	return parse.ParseLabels(o.Labels)
 }

--- a/pkg/cmd/addon/create/options.go
+++ b/pkg/cmd/addon/create/options.go
@@ -24,6 +24,9 @@ type Options struct {
 	// registration only supports clusterRoleBinding with cluster namespace
 	ClusterRoleBindingRef string
 
+	//Labels to add to created resources
+	Labels []string
+
 	FileNameFlags genericclioptions.FileNameFlags
 	//
 	Streams genericiooptions.IOStreams

--- a/pkg/cmd/addon/enable/cmd.go
+++ b/pkg/cmd/addon/enable/cmd.go
@@ -69,6 +69,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "open-cluster-management-agent-addon", "Specified namespace to deploy addon")
 	cmd.Flags().StringVar(&o.OutputFile, "output-file", "", "The generated resources will be copied in the specified file")
 	cmd.Flags().StringSliceVar(&o.Annotate, "annotate", []string{}, "Annotations to add to the ManagedClusterAddon (eg. key1=value1,key2=value2)")
+	cmd.Flags().StringSliceVar(&o.Labels, "labels", []string{}, "Labels to add to the ManagedClusterAddon (eg. key1=value1,key2=value2)")
 
 	return cmd
 }

--- a/pkg/cmd/addon/enable/exec.go
+++ b/pkg/cmd/addon/enable/exec.go
@@ -34,11 +34,24 @@ func NewClusterAddonInfo(cn string, o *Options, an string) (*addonv1alpha1.Manag
 		}
 		annos[annoSlice[0]] = annoSlice[1]
 	}
+
+	// Parse provided labels
+	labels := map[string]string{}
+	for _, labelString := range o.Labels {
+		labelSlice := strings.Split(labelString, "=")
+		if len(labelSlice) != 2 {
+			return nil,
+				fmt.Errorf("error parsing label '%s'. Expected to be of the form: key=value", labelString)
+		}
+		labels[labelSlice[0]] = labelSlice[1]
+	}
+
 	return &addonv1alpha1.ManagedClusterAddOn{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        an,
 			Namespace:   cn,
 			Annotations: annos,
+			Labels:      labels,
 		},
 		Spec: addonv1alpha1.ManagedClusterAddOnSpec{
 			InstallNamespace: o.Namespace,
@@ -144,6 +157,7 @@ func ApplyAddon(addonClient addonclientset.Interface, addon *addonv1alpha1.Manag
 	}
 
 	originalAddon.Annotations = addon.Annotations
+	originalAddon.Labels = addon.Labels
 	originalAddon.Spec.InstallNamespace = addon.Spec.InstallNamespace
 	_, err = addonClient.AddonV1alpha1().ManagedClusterAddOns(addon.Namespace).Update(context.TODO(), originalAddon, metav1.UpdateOptions{})
 	return err

--- a/pkg/cmd/addon/enable/exec.go
+++ b/pkg/cmd/addon/enable/exec.go
@@ -14,6 +14,7 @@ import (
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonclientset "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	"open-cluster-management.io/clusteradm/pkg/helpers/parse"
 )
 
 type ClusterAddonInfo struct {
@@ -36,14 +37,9 @@ func NewClusterAddonInfo(cn string, o *Options, an string) (*addonv1alpha1.Manag
 	}
 
 	// Parse provided labels
-	labels := map[string]string{}
-	for _, labelString := range o.Labels {
-		labelSlice := strings.Split(labelString, "=")
-		if len(labelSlice) != 2 {
-			return nil,
-				fmt.Errorf("error parsing label '%s'. Expected to be of the form: key=value", labelString)
-		}
-		labels[labelSlice[0]] = labelSlice[1]
+	labels, err := parse.ParseLabels(o.Labels)
+	if err != nil {
+		return nil, err
 	}
 
 	return &addonv1alpha1.ManagedClusterAddOn{

--- a/pkg/cmd/addon/enable/options.go
+++ b/pkg/cmd/addon/enable/options.go
@@ -19,6 +19,8 @@ type Options struct {
 	OutputFile string
 	//Annotations to add to the addon
 	Annotate []string
+	//Labels to add to the addon
+	Labels []string
 	//
 	Streams genericiooptions.IOStreams
 }

--- a/pkg/helpers/parse/parse.go
+++ b/pkg/helpers/parse/parse.go
@@ -1,0 +1,19 @@
+// Copyright Contributors to the Open Cluster Management project
+package parse
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ParseLabels(labels []string) (map[string]string, error) {
+	labelMap := make(map[string]string)
+	for _, labelString := range labels {
+		labelSlice := strings.Split(labelString, "=")
+		if len(labelSlice) != 2 {
+			return nil, fmt.Errorf("error parsing label '%s'. Expected to be of the form: key=value", labelString)
+		}
+		labelMap[labelSlice[0]] = labelSlice[1]
+	}
+	return labelMap, nil
+}

--- a/test/e2e/clusteradm/addon_lifecycle_test.go
+++ b/test/e2e/clusteradm/addon_lifecycle_test.go
@@ -114,7 +114,7 @@ var _ = ginkgo.Describe("test clusteradm with addon create", ginkgo.Label("addon
 				}
 
 				addonT, err := addonClient.AddonV1alpha1().AddOnTemplates().Get(
-					context.TODO(), "test-nginx", metav1.GetOptions{})
+					context.TODO(), "test-nginx-0.0.1", metav1.GetOptions{})
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR adds a new `--labels` flag to the `clusteradm addon create` and `clusteradm addon enable` commands. The flag takes comma-separated list of key=value pairs that will be added as labels to the AddOn resources created by the commands. 

Even though `enable` already supports annotations, labels are more useful when filtering resources, so I propose supporting both for that command.

## Related issue(s)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a --labels flag to addon create and enable commands to attach multiple key=value labels to created resources; invalid label formats produce a clear error.
- **Bug Fixes**
  - Ensures label changes are persisted when updating an existing add-on.
- **Tests**
  - Added end-to-end checks verifying labels propagate to management, template, and managed-cluster resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->