### PR TITLE
🐛  tweak argocd hub-addon install and uninstall

### DIFF
--- a/pkg/cmd/install/hubaddon/exec.go
+++ b/pkg/cmd/install/hubaddon/exec.go
@@ -169,6 +169,7 @@ func (o *Options) createNamespace() error {
 func (o *Options) runWithHelmClient(addon string) error {
 	if addon == argocdAddonName {
 		o.Helm.WithNamespace(argocdNamespace)
+		o.Helm.WithCreateNamespace(o.values.CreateNamespace)
 		if err := o.Helm.PrepareChart(repoName, url); err != nil {
 			return err
 		}

--- a/pkg/cmd/uninstall/hubaddon/exec.go
+++ b/pkg/cmd/uninstall/hubaddon/exec.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	argocdAddonName          = "argocd"
+	argocdNamespace          = "argocd"
 	argocdReleaseName        = "argocd-pull-integration"
 	policyFrameworkAddonName = "governance-policy-framework"
 )
@@ -148,6 +149,7 @@ func (o *Options) runWithHelmClient(addon string) error {
 	}
 
 	if addon == argocdAddonName {
+		o.Helm.WithNamespace(argocdNamespace)
 		if err := o.Helm.UninstallRelease(argocdReleaseName); err != nil {
 			return err
 		}

--- a/pkg/helpers/helm/helm.go
+++ b/pkg/helpers/helm/helm.go
@@ -29,8 +29,9 @@ import (
 const HelmFlagSetAnnotation = "HelmSet"
 
 type Helm struct {
-	settings *cli.EnvSettings
-	values   *values.Options
+	settings        *cli.EnvSettings
+	values          *values.Options
+	createNamespace bool
 }
 
 func NewHelm() *Helm {
@@ -46,6 +47,10 @@ func NewHelm() *Helm {
 
 func (h *Helm) WithNamespace(ns string) {
 	h.settings.SetNamespace(ns)
+}
+
+func (h *Helm) WithCreateNamespace(createNS bool) {
+	h.createNamespace = createNS
 }
 
 func (h *Helm) AddFlags(fs *pflag.FlagSet) {
@@ -157,6 +162,7 @@ func (h *Helm) InstallChart(name, repo, chart string) {
 		log.Fatal(err)
 	}
 	client := action.NewInstall(actionConfig)
+	client.CreateNamespace = h.createNamespace
 
 	if client.Version == "" && client.Devel {
 		client.Version = ">0.0.0-0"


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Fixes 2 small issues related to the `argocd` hub addon.

- In `clusteradm install hub-addon --names argocd --create-namespace`, set the helm client `CreateNamespace` option, to prevent the following error:
```bash
create: failed to create: namespaces "argocd" not found
```

- When `clusteradm uninstall hub-addon --names argocd`, the namespace was not being set in the client, causing the uninstall to fail with the following error:
```bash
Error: uninstall: Release not loaded: argocd-pull-integration: release: not found
```

## Related issue(s)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to automatically create the namespace when installing the Argo CD add-on, controlled by your existing configuration.
- Bug Fixes
  - Uninstalling the Argo CD add-on now correctly targets the Argo CD namespace, improving reliability of removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->