### PR TITLE
🐛 dynamically set labelSelector when checking for reg operator

### DIFF
--- a/pkg/cmd/init/exec.go
+++ b/pkg/cmd/init/exec.go
@@ -20,6 +20,7 @@ import (
 	ocmfeature "open-cluster-management.io/api/feature"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 	"open-cluster-management.io/clusteradm/pkg/cmd/init/preflight"
+	"open-cluster-management.io/clusteradm/pkg/config"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 	"open-cluster-management.io/clusteradm/pkg/helpers/helm"
@@ -234,7 +235,8 @@ func (o *Options) run() error {
 			if err := helperwait.WaitUntilRegistrationOperatorReady(
 				o.Streams.Out,
 				o.ClusteradmFlags.KubectlFactory,
-				int64(o.ClusteradmFlags.Timeout)); err != nil {
+				int64(o.ClusteradmFlags.Timeout),
+				config.ClusterManagerName); err != nil {
 				return err
 			}
 		}

--- a/pkg/cmd/upgrade/clustermanager/exec.go
+++ b/pkg/cmd/upgrade/clustermanager/exec.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
+	"open-cluster-management.io/clusteradm/pkg/config"
 	"open-cluster-management.io/clusteradm/pkg/helpers/reader"
 	"open-cluster-management.io/clusteradm/pkg/version"
 	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"
@@ -116,7 +117,8 @@ func (o *Options) run() error {
 		if err := wait.WaitUntilRegistrationOperatorReady(
 			o.Streams.Out,
 			o.ClusteradmFlags.KubectlFactory,
-			int64(o.ClusteradmFlags.Timeout)); err != nil {
+			int64(o.ClusteradmFlags.Timeout),
+			config.ClusterManagerName); err != nil {
 			return err
 		}
 	}

--- a/pkg/cmd/upgrade/klusterlet/exec.go
+++ b/pkg/cmd/upgrade/klusterlet/exec.go
@@ -11,17 +11,13 @@ import (
 	"k8s.io/klog/v2"
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 
+	"open-cluster-management.io/clusteradm/pkg/config"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 	"open-cluster-management.io/clusteradm/pkg/helpers/klusterlet"
 	"open-cluster-management.io/clusteradm/pkg/helpers/reader"
 	"open-cluster-management.io/clusteradm/pkg/helpers/wait"
 	"open-cluster-management.io/clusteradm/pkg/version"
 	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"
-)
-
-//nolint:deadcode,varcheck
-const (
-	klusterletName = "klusterlet"
 )
 
 func (o *Options) complete(_ *cobra.Command, _ []string) (err error) {
@@ -41,7 +37,7 @@ func (o *Options) complete(_ *cobra.Command, _ []string) (err error) {
 		return err
 	}
 
-	k, err := operatorClient.OperatorV1().Klusterlets().Get(context.TODO(), klusterletName, metav1.GetOptions{})
+	k, err := operatorClient.OperatorV1().Klusterlets().Get(context.TODO(), config.KlusterletName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -141,7 +137,8 @@ func (o *Options) run() error {
 		if err := wait.WaitUntilRegistrationOperatorReady(
 			o.Streams.Out,
 			o.ClusteradmFlags.KubectlFactory,
-			int64(o.ClusteradmFlags.Timeout)); err != nil {
+			int64(o.ClusteradmFlags.Timeout),
+			config.KlusterletName); err != nil {
 			return err
 		}
 	}

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -9,6 +9,7 @@ const (
 	BootstrapClusterRoleBindingSAName = "agent-registration-bootstrap"
 	BootstrapClusterRoleName          = "open-cluster-management:bootstrap"
 	ClusterManagerName                = "cluster-manager"
+	KlusterletName                    = "klusterlet"
 	LabelApp                          = "app"
 	BootstrapSecretPrefix             = "bootstrap-token-"
 	HubClusterNamespace               = "open-cluster-management-hub"

--- a/pkg/helpers/wait/wait.go
+++ b/pkg/helpers/wait/wait.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubectl/pkg/cmd/util"
+	"open-cluster-management.io/clusteradm/pkg/config"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"
 )
@@ -35,7 +36,7 @@ func WaitUntilCRDReady(w io.Writer, apiExtensionsClient apiextensionsclient.Inte
 	return helpers.WaitCRDToBeReady(apiExtensionsClient, crdName, b, wait)
 }
 
-func WaitUntilRegistrationOperatorReady(w io.Writer, f util.Factory, timeout int64) error {
+func WaitUntilRegistrationOperatorReady(w io.Writer, f util.Factory, timeout int64, appLabel string) error {
 	var restConfig *rest.Config
 	restConfig, err := f.ToRESTConfig()
 	if err != nil {
@@ -65,7 +66,7 @@ func WaitUntilRegistrationOperatorReady(w io.Writer, f util.Factory, timeout int
 			return client.CoreV1().Pods("open-cluster-management").
 				Watch(context.TODO(), metav1.ListOptions{
 					TimeoutSeconds: &timeout,
-					LabelSelector:  "app=cluster-manager",
+					LabelSelector:  fmt.Sprintf("%v=%v", config.LabelApp, appLabel),
 				})
 		},
 		func(event watch.Event) bool {

--- a/test/e2e/clusteradm/upgrade_test.go
+++ b/test/e2e/clusteradm/upgrade_test.go
@@ -88,6 +88,7 @@ var _ = ginkgo.Describe("test clusteradm upgrade clustermanager and klusterlets"
 			"clustermanager",
 			"--bundle-version=latest",
 			"--context", e2e.Cluster().Hub().Context(),
+			"--wait",
 		)
 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "clusteradm upgrade error")
@@ -116,6 +117,7 @@ var _ = ginkgo.Describe("test clusteradm upgrade clustermanager and klusterlets"
 			"klusterlet",
 			"--bundle-version=latest",
 			"--context", e2e.Cluster().ManagedCluster1().Context(),
+			"--wait",
 		)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "klusterlet upgrade error")
 


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Using the  `--wait` flag with `clusteradm upgrade klusterlet` currently causes the command to time out, despite the upgrade succeeding. This is because the `WaitUntilRegistrationOperatorReady()` is always checking to find a pod with the label `app=cluster-manager`. This is correct behaviour for the `init` and `upgrade clustermanager` commands, but for the `upgrade klusterlet` command, the function needs to wait for a pod with `app=klusterlet`.

## Related issue(s)

Fixes #
