### PR TITLE
✨ Add --config-file flag to addon enable command

### DIFF
--- a/pkg/cmd/addon/disable/exec_test.go
+++ b/pkg/cmd/addon/disable/exec_test.go
@@ -60,7 +60,7 @@ var _ = ginkgo.Describe("addon disable", func() {
 			for _, clus := range clusters {
 				ginkgo.By(fmt.Sprintf("Enabling %s addon on %s cluster in %s namespace", addon, clus, ns))
 
-				cai, err := enable.NewClusterAddonInfo(clus, o, addon)
+				cai, err := enable.NewClusterAddonInfo(clus, o, addon, nil)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "enable addon error")
 				err = enable.ApplyAddon(addonClient, cai)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "enable addon error")

--- a/pkg/cmd/addon/enable/cmd.go
+++ b/pkg/cmd/addon/enable/cmd.go
@@ -32,6 +32,11 @@ var example = `
 %[1]s addon enable --names config-policy-controller --namespace namespace --clusters cluster1,cluster2
 # Enable config-policy-controller addon for specified clusters
 %[1]s addon enable --names config-policy-controller --clusters cluster1,cluster2
+
+## With Configuration File
+
+# Enable addon with configurations from a file
+%[1]s addon enable --names my-addon --clusters cluster1 --config-file addon-config.yaml
 `
 
 // NewCmd...
@@ -70,6 +75,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	cmd.Flags().StringVar(&o.OutputFile, "output-file", "", "The generated resources will be copied in the specified file")
 	cmd.Flags().StringSliceVar(&o.Annotate, "annotate", []string{}, "Annotations to add to the ManagedClusterAddon (eg. key1=value1,key2=value2)")
 	cmd.Flags().StringSliceVar(&o.Labels, "labels", []string{}, "Labels to add to the ManagedClusterAddon (eg. key1=value1,key2=value2)")
+	cmd.Flags().StringVar(&o.ConfigFile, "config-file", "", "Path to the configuration file containing addon configs (YAML format with group, resource, namespace, and name)")
 
 	return cmd
 }

--- a/pkg/cmd/addon/enable/options.go
+++ b/pkg/cmd/addon/enable/options.go
@@ -21,6 +21,8 @@ type Options struct {
 	Annotate []string
 	//Labels to add to the addon
 	Labels []string
+	//The config file to load addon configurations from
+	ConfigFile string
 	//
 	Streams genericiooptions.IOStreams
 }

--- a/pkg/cmd/addon/enable/suite_test.go
+++ b/pkg/cmd/addon/enable/suite_test.go
@@ -8,12 +8,20 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterv1client "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 
 // nolint:deadcode,varcheck
@@ -29,6 +37,7 @@ var restConfig *rest.Config
 var kubeClient kubernetes.Interface
 var clusterClient clusterv1client.Interface
 var addonClient addonv1alpha1client.Interface
+var testFlags *genericclioptionsclusteradm.ClusteradmFlags
 
 func TestIntegrationEnableAddons(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
@@ -59,6 +68,10 @@ var _ = ginkgo.BeforeSuite(func() {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	restConfig = cfg
+
+	// Set up testFlags with a factory that uses the test config
+	f := cmdutil.NewFactory(TestClientGetter{cfg: cfg})
+	testFlags = genericclioptionsclusteradm.NewClusteradmFlags(f)
 })
 
 var _ = ginkgo.AfterSuite(func() {
@@ -67,3 +80,27 @@ var _ = ginkgo.AfterSuite(func() {
 	err := testEnv.Stop()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 })
+
+type TestClientGetter struct {
+	cfg *rest.Config
+}
+
+func (t TestClientGetter) ToRESTConfig() (*rest.Config, error) {
+	return t.cfg, nil
+}
+
+func (t TestClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	discoveryClient, _ := discovery.NewDiscoveryClientForConfig(t.cfg)
+	return memory.NewMemCacheClient(discoveryClient), nil
+}
+
+// ToRESTMapper returns a restmapper
+func (t TestClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	client, _ := t.ToDiscoveryClient()
+	return restmapper.NewDeferredDiscoveryRESTMapper(client), nil
+}
+
+// ToRawKubeConfigLoader return kubeconfig loader as-is
+func (t TestClientGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, nil)
+}


### PR DESCRIPTION
This commit implements the feature requested in issue #501 by adding a --config-file flag to the addon enable command. The flag allows users to specify addon configurations that will be applied to the cluster and referenced in the ManagedClusterAddOn resource.

Changes:
- Added ConfigFile field to Options struct
- Added --config-file flag to the enable command
- Implemented applyConfigFileAndBuildReferences() function that:
  - Reads configuration resources from a YAML file
  - Applies the resources to the cluster using ResourceReader
  - Uses REST mapper to discover GVR (Group/Version/Resource)
  - Builds AddOnConfig references with proper group, resource, namespace, and name
- Updated NewClusterAddonInfo() to accept configs as a parameter
- Updated runWithClient() to apply config file before creating addons
- Updated ApplyAddon() to handle configs when updating existing addons
- Added comprehensive integration tests for the new functionality
- Added TestClientGetter helper for test setup

The config file should contain actual Kubernetes resources (e.g., AddOnDeploymentConfig) in YAML format. Multiple resources can be separated by '---'. The implementation automatically discovers the resource type and builds proper references that are set in the ManagedClusterAddOn.Spec.Configs field.

Example usage:
  clusteradm addon enable --names my-addon --clusters cluster1 \
    --config-file addon-config.yaml

Fixes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --config-file flag to the addon enable command to load addon configurations from a YAML file; supports multiple configs in one file and creates corresponding deployment-config resources.
* **Behavior**
  * Config references are preserved when creating or updating the managed cluster add-on; enabling without a config file remains unchanged.
* **Tests**
  * New integration tests cover single/multiple configs, no-config path, and missing-file error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->