### PR TITLE
✨ Add --placement-ref flag to addon create command

### DIFF
--- a/pkg/cmd/addon/create/cmd.go
+++ b/pkg/cmd/addon/create/cmd.go
@@ -52,6 +52,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	cmd.Flags().StringVar(&o.ClusterRoleBindingRef, "cluster-role-bind", "", "The rolebinding to the clusterrole in "+
 		"the cluster namespace for the addon agent")
 	cmd.Flags().StringSliceVar(&o.Labels, "labels", []string{}, "Labels to add to the ClusterManagementAddOn and AddOnTemplate resources (eg. key1=value1,key2=value2)")
+	cmd.Flags().StringVar(&o.PlacementRef, "placement-ref", "", "The namespace/name reference to a Placement resource for automatic addon installation (eg. namespace/placement-name)")
 	o.FileNameFlags.AddFlags(cmd.Flags())
 
 	return cmd

--- a/pkg/cmd/addon/create/exec_test.go
+++ b/pkg/cmd/addon/create/exec_test.go
@@ -1,0 +1,331 @@
+// Copyright Contributors to the Open Cluster Management project
+package create
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/utils/ptr"
+
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+)
+
+var _ = ginkgo.Describe("addon create", func() {
+
+	var (
+		suffix string
+		err    error
+	)
+
+	ginkgo.BeforeEach(func() {
+		suffix = rand.String(5)
+	})
+
+	streams := genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+
+	ginkgo.Context("parsePlacementRef", func() {
+		ginkgo.It("Should parse valid placement-ref correctly", func() {
+			o := &Options{
+				PlacementRef: "test-namespace/test-placement",
+			}
+
+			namespace, name, err := o.parsePlacementRef()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(namespace).To(gomega.Equal("test-namespace"))
+			gomega.Expect(name).To(gomega.Equal("test-placement"))
+		})
+
+		ginkgo.It("Should handle empty placement-ref", func() {
+			o := &Options{
+				PlacementRef: "",
+			}
+
+			namespace, name, err := o.parsePlacementRef()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(namespace).To(gomega.Equal(""))
+			gomega.Expect(name).To(gomega.Equal(""))
+		})
+
+		ginkgo.It("Should return error for invalid format (no slash)", func() {
+			o := &Options{
+				PlacementRef: "invalid-format",
+			}
+
+			_, _, err := o.parsePlacementRef()
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("must be in the format 'namespace/name'"))
+		})
+
+		ginkgo.It("Should return error for invalid format (too many slashes)", func() {
+			o := &Options{
+				PlacementRef: "namespace/name/extra",
+			}
+
+			_, _, err := o.parsePlacementRef()
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("must be in the format 'namespace/name'"))
+		})
+
+		ginkgo.It("Should return error for empty namespace", func() {
+			o := &Options{
+				PlacementRef: "/placement-name",
+			}
+
+			_, _, err := o.parsePlacementRef()
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("namespace and name cannot be empty"))
+		})
+
+		ginkgo.It("Should return error for empty name", func() {
+			o := &Options{
+				PlacementRef: "namespace/",
+			}
+
+			_, _, err := o.parsePlacementRef()
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("namespace and name cannot be empty"))
+		})
+
+		ginkgo.It("Should trim whitespace from namespace and name", func() {
+			o := &Options{
+				PlacementRef: " test-namespace / test-placement ",
+			}
+
+			namespace, name, err := o.parsePlacementRef()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(namespace).To(gomega.Equal("test-namespace"))
+			gomega.Expect(name).To(gomega.Equal("test-placement"))
+		})
+	})
+
+	ginkgo.Context("newClusterManagementAddon", func() {
+		ginkgo.It("Should create ClusterManagementAddOn with Manual install strategy when placement-ref is not provided", func() {
+			// Create a temporary manifest file
+			tmpFile, err := os.CreateTemp("", "manifest-*.yaml")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			defer os.Remove(tmpFile.Name())
+
+			manifestContent := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value`
+
+			_, err = tmpFile.WriteString(manifestContent)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			tmpFile.Close()
+
+			o := &Options{
+				Name:          fmt.Sprintf("test-addon-%s", suffix),
+				Version:       "0.0.1",
+				PlacementRef:  "",
+				Labels:        []string{},
+				FileNameFlags: genericclioptions.FileNameFlags{Filenames: &[]string{tmpFile.Name()}, Recursive: ptr.To[bool](true)},
+				Streams:       streams,
+			}
+
+			cma, err := newClusterManagementAddon(o)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(cma.Spec.InstallStrategy.Type).To(gomega.Equal(addonapiv1alpha1.AddonInstallStrategyManual))
+			gomega.Expect(cma.Spec.InstallStrategy.Placements).To(gomega.BeNil())
+		})
+
+		ginkgo.It("Should create ClusterManagementAddOn with Placements install strategy when placement-ref is provided", func() {
+			// Create a temporary manifest file
+			tmpFile, err := os.CreateTemp("", "manifest-*.yaml")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			defer os.Remove(tmpFile.Name())
+
+			manifestContent := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value`
+
+			_, err = tmpFile.WriteString(manifestContent)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			tmpFile.Close()
+
+			placementNamespace := fmt.Sprintf("placement-ns-%s", suffix)
+			placementName := fmt.Sprintf("placement-%s", suffix)
+
+			o := &Options{
+				Name:          fmt.Sprintf("test-addon-%s", suffix),
+				Version:       "0.0.1",
+				PlacementRef:  fmt.Sprintf("%s/%s", placementNamespace, placementName),
+				Labels:        []string{},
+				FileNameFlags: genericclioptions.FileNameFlags{Filenames: &[]string{tmpFile.Name()}, Recursive: ptr.To[bool](true)},
+				Streams:       streams,
+			}
+
+			cma, err := newClusterManagementAddon(o)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(cma.Spec.InstallStrategy.Type).To(gomega.Equal(addonapiv1alpha1.AddonInstallStrategyPlacements))
+			gomega.Expect(cma.Spec.InstallStrategy.Placements).To(gomega.HaveLen(1))
+			gomega.Expect(cma.Spec.InstallStrategy.Placements[0].Namespace).To(gomega.Equal(placementNamespace))
+			gomega.Expect(cma.Spec.InstallStrategy.Placements[0].Name).To(gomega.Equal(placementName))
+		})
+
+		ginkgo.It("Should return error when placement-ref format is invalid", func() {
+			// Create a temporary manifest file
+			tmpFile, err := os.CreateTemp("", "manifest-*.yaml")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			defer os.Remove(tmpFile.Name())
+
+			manifestContent := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value`
+
+			_, err = tmpFile.WriteString(manifestContent)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			tmpFile.Close()
+
+			o := &Options{
+				Name:          fmt.Sprintf("test-addon-%s", suffix),
+				Version:       "0.0.1",
+				PlacementRef:  "invalid-format-no-slash",
+				Labels:        []string{},
+				FileNameFlags: genericclioptions.FileNameFlags{Filenames: &[]string{tmpFile.Name()}, Recursive: ptr.To[bool](true)},
+				Streams:       streams,
+			}
+
+			_, err = newClusterManagementAddon(o)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("must be in the format 'namespace/name'"))
+		})
+	})
+
+	ginkgo.Context("integration test with actual creation", func() {
+		var addonName string
+
+		ginkgo.AfterEach(func() {
+			// Clean up ClusterManagementAddOn
+			if addonName != "" {
+				err = addonClient.AddonV1alpha1().ClusterManagementAddOns().Delete(
+					context.Background(), addonName, metav1.DeleteOptions{})
+				if err != nil && !errors.IsNotFound(err) {
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				}
+			}
+
+			// Clean up AddOnTemplate
+			if addonName != "" {
+				templateName := fmt.Sprintf("%s-0.0.1", addonName)
+				err = addonClient.AddonV1alpha1().AddOnTemplates().Delete(
+					context.Background(), templateName, metav1.DeleteOptions{})
+				if err != nil && !errors.IsNotFound(err) {
+					gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				}
+			}
+		})
+
+		ginkgo.It("Should create ClusterManagementAddOn with placement reference", func() {
+			addonName = fmt.Sprintf("test-addon-%s", suffix)
+			placementNamespace := fmt.Sprintf("placement-ns-%s", suffix)
+			placementName := fmt.Sprintf("placement-%s", suffix)
+
+			// Create a temporary manifest file
+			tmpFile, err := os.CreateTemp("", "manifest-*.yaml")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			defer os.Remove(tmpFile.Name())
+
+			manifestContent := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value`
+
+			_, err = tmpFile.WriteString(manifestContent)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			tmpFile.Close()
+
+			o := &Options{
+				ClusteradmFlags: testFlags,
+				Name:            addonName,
+				Version:         "0.0.1",
+				PlacementRef:    fmt.Sprintf("%s/%s", placementNamespace, placementName),
+				Labels:          []string{},
+				FileNameFlags:   genericclioptions.FileNameFlags{Filenames: &[]string{tmpFile.Name()}, Recursive: ptr.To[bool](true)},
+				Streams:         streams,
+			}
+
+			err = o.Run()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			// Verify ClusterManagementAddOn was created with correct install strategy
+			cma, err := addonClient.AddonV1alpha1().ClusterManagementAddOns().Get(
+				context.Background(), addonName, metav1.GetOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(cma.Spec.InstallStrategy.Type).To(gomega.Equal(addonapiv1alpha1.AddonInstallStrategyPlacements))
+			gomega.Expect(cma.Spec.InstallStrategy.Placements).To(gomega.HaveLen(1))
+			gomega.Expect(cma.Spec.InstallStrategy.Placements[0].Namespace).To(gomega.Equal(placementNamespace))
+			gomega.Expect(cma.Spec.InstallStrategy.Placements[0].Name).To(gomega.Equal(placementName))
+
+			// Verify AddOnTemplate was created
+			templateName := fmt.Sprintf("%s-0.0.1", addonName)
+			template, err := addonClient.AddonV1alpha1().AddOnTemplates().Get(
+				context.Background(), templateName, metav1.GetOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(template.Spec.AddonName).To(gomega.Equal(addonName))
+		})
+
+		ginkgo.It("Should create ClusterManagementAddOn without placement reference", func() {
+			addonName = fmt.Sprintf("test-addon-no-placement-%s", suffix)
+
+			// Create a temporary manifest file
+			tmpFile, err := os.CreateTemp("", "manifest-*.yaml")
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			defer os.Remove(tmpFile.Name())
+
+			manifestContent := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-config
+  namespace: default
+data:
+  key: value`
+
+			_, err = tmpFile.WriteString(manifestContent)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			tmpFile.Close()
+
+			o := &Options{
+				ClusteradmFlags: testFlags,
+				Name:            addonName,
+				Version:         "0.0.1",
+				PlacementRef:    "",
+				Labels:          []string{},
+				FileNameFlags:   genericclioptions.FileNameFlags{Filenames: &[]string{tmpFile.Name()}, Recursive: ptr.To[bool](true)},
+				Streams:         streams,
+			}
+
+			err = o.Run()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			// Verify ClusterManagementAddOn was created with Manual install strategy
+			cma, err := addonClient.AddonV1alpha1().ClusterManagementAddOns().Get(
+				context.Background(), addonName, metav1.GetOptions{})
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(cma.Spec.InstallStrategy.Type).To(gomega.Equal(addonapiv1alpha1.AddonInstallStrategyManual))
+			gomega.Expect(cma.Spec.InstallStrategy.Placements).To(gomega.BeNil())
+		})
+	})
+})

--- a/pkg/cmd/addon/create/options.go
+++ b/pkg/cmd/addon/create/options.go
@@ -27,6 +27,9 @@ type Options struct {
 	//Labels to add to created resources
 	Labels []string
 
+	// PlacementRef is the namespace/name reference to a Placement resource
+	PlacementRef string
+
 	FileNameFlags genericclioptions.FileNameFlags
 	//
 	Streams genericiooptions.IOStreams

--- a/pkg/cmd/addon/create/suite_test.go
+++ b/pkg/cmd/addon/create/suite_test.go
@@ -1,0 +1,89 @@
+// Copyright Contributors to the Open Cluster Management project
+package create
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
+	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
+)
+
+var testEnv *envtest.Environment
+var addonClient addonv1alpha1client.Interface
+var testFlags *genericclioptionsclusteradm.ClusteradmFlags
+
+func TestIntegrationCreateAddons(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Integration Create Addons Suite")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	ginkgo.By("bootstrapping test environment")
+
+	// start a kube-apiserver
+	testEnv = &envtest.Environment{
+		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "..", "vendor", "open-cluster-management.io", "api", "cluster", "v1"),
+			filepath.Join("..", "..", "..", "..", "vendor", "open-cluster-management.io", "api", "addon", "v1alpha1"),
+		},
+	}
+
+	cfg, err := testEnv.Start()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	gomega.Expect(cfg).ToNot(gomega.BeNil())
+
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	addonClient, err = addonv1alpha1client.NewForConfig(cfg)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Set up testFlags with a factory that uses the test config
+	f := cmdutil.NewFactory(TestClientGetter{cfg: cfg})
+	testFlags = genericclioptionsclusteradm.NewClusteradmFlags(f)
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	ginkgo.By("tearing down the test environment")
+
+	err := testEnv.Stop()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+})
+
+type TestClientGetter struct {
+	cfg *rest.Config
+}
+
+func (t TestClientGetter) ToRESTConfig() (*rest.Config, error) {
+	return t.cfg, nil
+}
+
+func (t TestClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	discoveryClient, _ := discovery.NewDiscoveryClientForConfig(t.cfg)
+	return memory.NewMemCacheClient(discoveryClient), nil
+}
+
+// ToRESTMapper returns a restmapper
+func (t TestClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	client, _ := t.ToDiscoveryClient()
+	return restmapper.NewDeferredDiscoveryRESTMapper(client), nil
+}
+
+// ToRawKubeConfigLoader return kubeconfig loader as-is
+func (t TestClientGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return clientcmd.NewDefaultClientConfig(clientcmdapi.Config{}, nil)
+}


### PR DESCRIPTION
This commit adds support for the --placement-ref flag to the addon create command, allowing users to specify a Placement resource reference for automatic addon installation.

Changes:
- Add PlacementRef field to Options struct
- Add --placement-ref flag accepting namespace/name format
- Implement parsePlacementRef() to parse and validate the flag value
- Update newClusterManagementAddon() to set InstallStrategy based on flag
  - Manual strategy when flag is not provided (default behavior)
  - Placements strategy when flag is provided
- Add validation for placement-ref format
- Add comprehensive test coverage with 12 test cases including:
  - Unit tests for parsePlacementRef()
  - Unit tests for newClusterManagementAddon()
  - Integration tests for end-to-end functionality

Fixes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--placement-ref` CLI flag to the addon create command
  * Addon install strategy automatically switches from Manual to Placements when a placement-ref is provided
  * Placement-ref validation ensures correct namespace/name format

* **Tests**
  * Added comprehensive test suite covering placement-ref parsing, validation, and error cases
  * Added integration tests verifying addon creation with and without placement-refs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->