### PR TITLE
:sparkles: support enable grpc registration when clusteradm init

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	open-cluster-management.io/api v1.1.0
 	open-cluster-management.io/cluster-proxy v0.7.0
 	open-cluster-management.io/managed-serviceaccount v0.8.0
-	open-cluster-management.io/ocm v1.1.0
+	open-cluster-management.io/ocm v1.1.1-0.20251105064423-d80ec55608e7
 	open-cluster-management.io/sdk-go v1.1.0
 	sigs.k8s.io/apiserver-network-proxy v0.29.0
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2

--- a/go.sum
+++ b/go.sum
@@ -484,8 +484,8 @@ open-cluster-management.io/cluster-proxy v0.7.0 h1:qOok0BIBL6j4mLRArzJdz0gK5nyyn
 open-cluster-management.io/cluster-proxy v0.7.0/go.mod h1:6cgnExpuprO7Le7aqf7bI3H7Nvu3YnXBJCIbJ7wsC0s=
 open-cluster-management.io/managed-serviceaccount v0.8.0 h1:8+Z142IUqVT/enxXkyb0nzLUL7JaR7dBM2fDtlCA4pM=
 open-cluster-management.io/managed-serviceaccount v0.8.0/go.mod h1:eTixwpLA6XkPQARDjze3k0KRjwn6N22eFOEFx8CpB0I=
-open-cluster-management.io/ocm v1.1.0 h1:Gu5+LYMHMCNxE1StB2x9SyH1E1K1cNOTdUrp1Id++T8=
-open-cluster-management.io/ocm v1.1.0/go.mod h1:vuIzDonz/ypkaLNqXvjOHSwMA29x+e25s01S8Z0j3gc=
+open-cluster-management.io/ocm v1.1.1-0.20251105064423-d80ec55608e7 h1:wRA9v3BH1mfxZiMZVgc0Ert2JziNbekUcg4PpPQUrLk=
+open-cluster-management.io/ocm v1.1.1-0.20251105064423-d80ec55608e7/go.mod h1:LlEIZdZrQQduPS6HqFKvdadtFjOfVJzBj80/Ur+exP8=
 open-cluster-management.io/sdk-go v1.1.0 h1:vYGkoihIVetyVT4ICO7HjoUHsnh6Gf+Da4ZSmWCamhc=
 open-cluster-management.io/sdk-go v1.1.0/go.mod h1:DH4EMNDMiousmaj+noHYQxm48T+dbogiAfALhDnrjMg=
 oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=

--- a/pkg/cmd/init/cmd.go
+++ b/pkg/cmd/init/cmd.go
@@ -16,7 +16,7 @@ var example = `
 %[1]s init
 
 # Initialize the hub cluster with the type of authentication. Either or both of csr,awsirsa
-%[1]s init --registration-drivers "awsirsa,csr"
+%[1]s init --registration-drivers "awsirsa,csr,grpc"
     --hubClusterArn arn:aws:eks:us-west-2:123456789012:cluster/hub-cluster1
 	--aws-resource-tags product:v1:tenant:app-name=My-App,product:v1:tenant:created-by=Team-1
     --auto-approved-csr-identities="user1,user2"
@@ -89,7 +89,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	o.Helm.AddFlags(singletonSet)
 	cmd.Flags().AddFlagSet(singletonSet)
 	cmd.Flags().StringSliceVar(&o.registrationDrivers, "registration-drivers", []string{},
-		"The type of authentication to use for registering and authenticating with hub. Only csr and awsirsa are accepted as valid inputs. This flag can be repeated to specify multiple authentication types.")
+		"The type of authentication to use for registering and authenticating with hub. Only csr, awsirsa and grpc are accepted as valid inputs. This flag can be repeated to specify multiple authentication types.")
 	cmd.Flags().StringVar(&o.hubClusterArn, "hub-cluster-arn", "",
 		"The hubCluster ARN to be passed if awsirsa is one of the registrationAuths and the cluster name in EKS kubeconfig doesn't contain hubClusterArn")
 	cmd.Flags().StringSliceVar(&o.awsResourceTags, "aws-resource-tags", []string{},
@@ -100,6 +100,8 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	cmd.Flags().StringSliceVar(&o.autoApprovedARNPatterns, "auto-approved-arn-patterns", []string{},
 		"List of AWS EKS ARN patterns so any EKS clusters with these patterns will be auto accepted to join with hub cluster")
 	cmd.Flags().BoolVar(&o.enableSyncLabels, "enable-sync-labels", false, "If true, sync the labels from clustermanager to all hub resources.")
-
+	cmd.Flags().StringVar(&o.grpcServer, "grpc-server", "", "The gRPC server address of the hub")
+	cmd.Flags().StringSliceVar(&o.autoApprovedGRPCIdentities, "auto-approved-grpc-identities", []string{},
+		"List of users or identities that are accepted and whatever matches can be auto accepted to join hub for grpc clusters")
 	return cmd
 }

--- a/pkg/cmd/init/options.go
+++ b/pkg/cmd/init/options.go
@@ -67,6 +67,12 @@ type Options struct {
 	awsResourceTags []string
 	// enableSyncLabels is to enable the feature which can sync the labels from clustermanager to all hub resources.
 	enableSyncLabels bool
+
+	// grpcServer is the gRPC server of the hub.
+	grpcServer string
+	// autoApprovedGRPCIdentities are a list of users or identities that are accepted and whatever matches can
+	// be auto accepted to join hub for grpc clusters.
+	autoApprovedGRPCIdentities []string
 }
 
 func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, streams genericiooptions.IOStreams) *Options {

--- a/test/e2e/util/helper.go
+++ b/test/e2e/util/helper.go
@@ -120,7 +120,9 @@ func WaitClustersDeleted(restcfg *rest.Config) error {
 				return err
 			}
 		}
-		return fmt.Errorf("wait all clusters are deleted: %v", clusterList.Items)
+
+		fmt.Printf("wait for all clusters to be deleted: %+v\n", clusterList.Items)
+		return fmt.Errorf("not all clusters are deleted")
 	}, time.Second*300, time.Second*2).Should(gomega.Succeed())
 
 	return nil

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -73,7 +73,7 @@ func initE2E() (*TestE2eConfig, error) {
 			return err
 		}
 
-		fmt.Println("unjoin managedcluster1...")
+		fmt.Println("unjoin managedCluster on the spoke cluster...")
 		err := e2eConf.Clusteradm().Unjoin(
 			"--context", e2eConf.Cluster().ManagedCluster1().Context(),
 			"--cluster-name", e2eConf.Cluster().ManagedCluster1().Name(),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1270,7 +1270,7 @@ open-cluster-management.io/managed-serviceaccount/pkg/generated/clientset/versio
 open-cluster-management.io/managed-serviceaccount/pkg/generated/clientset/versioned/scheme
 open-cluster-management.io/managed-serviceaccount/pkg/generated/clientset/versioned/typed/authentication/v1alpha1
 open-cluster-management.io/managed-serviceaccount/pkg/generated/clientset/versioned/typed/authentication/v1beta1
-# open-cluster-management.io/ocm v1.1.0
+# open-cluster-management.io/ocm v1.1.1-0.20251105064423-d80ec55608e7
 ## explicit; go 1.24.0
 open-cluster-management.io/ocm/deploy/cluster-manager/chart
 open-cluster-management.io/ocm/deploy/klusterlet/chart

--- a/vendor/open-cluster-management.io/ocm/deploy/cluster-manager/chart/cluster-manager/templates/cluster_manager.yaml
+++ b/vendor/open-cluster-management.io/ocm/deploy/cluster-manager/chart/cluster-manager/templates/cluster_manager.yaml
@@ -41,4 +41,8 @@ spec:
   addOnManagerConfiguration:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.clusterManager.serverConfiguration }}
+  serverConfiguration:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/vendor/open-cluster-management.io/ocm/deploy/cluster-manager/chart/cluster-manager/values.yaml
+++ b/vendor/open-cluster-management.io/ocm/deploy/cluster-manager/chart/cluster-manager/values.yaml
@@ -21,6 +21,19 @@ images:
   # Please set the userName/password or the dockerConfigJson if you use a private image registry.
   # The registry will be set in the generated credential if you set userName/password.
   # Suggest to use dockerConfigJson if you set overrides here.
+  # For example: 
+  # --set-file images.imageCredentials.dockerConfigJson=<your dockerConfigJson file> ,
+  # or set the json context in values.yaml file 
+  # dockerConfigJson: |
+  #   {
+  #     "auths": {
+  #       "<your registry>": {
+  #         "auth": "xxx",
+  #         "email": "xxx"
+  #     }
+  #   }
+  # }
+  #
   # The image pull secret is fixed into the serviceAccount, you can also set
   # `createImageCredentials` to `false` and create the pull secret manually.
   imageCredentials:
@@ -100,9 +113,20 @@ clusterManager:
       mode: Enable
     registrationDrivers:
     - authType: csr
+#   - authType: grpc
+#   grpc:
+#     autoApprovedIdentities:
+#     - system:serviceaccount:open-cluster-management:agent-registration-bootstrap
   workConfiguration:
     workDriver: kube
   addOnManagerConfiguration: {}
 #   featureGates:
 #     - feature: ""
 #       mode: ""
+# serverConfiguration:
+#   endpointsExposure:
+#   - protocol: grpc
+#     grpc:
+#       type: hostname
+#       hostname:
+#         host: grpc-server-open-cluster-management-hub.apps.server-foundation-sno-lite-w8rlq.dev04.red-chesterfield.com

--- a/vendor/open-cluster-management.io/ocm/deploy/klusterlet/chart/klusterlet/values.yaml
+++ b/vendor/open-cluster-management.io/ocm/deploy/klusterlet/chart/klusterlet/values.yaml
@@ -11,13 +11,26 @@ images:
   # registry and tag work on all images, but the image will be replaced by overrides if the image in overrides is not empty.
   # The registry name must NOT contain a trailing slash.
   registry: quay.io/open-cluster-management
-  # The image tag is the appVersion by default, can be replaced by this version.
+  # The image tag is the appVersion by default, can be replaced by this version, for example v1.0.0.
   tag: ""
   imagePullPolicy: IfNotPresent
   # The image pull secret name is open-cluster-management-image-pull-credentials.
   # Please set the userName/password or the dockerConfigJson if you use a private image registry.
   # The registry will be set in the generated credential if you set userName/password.
-  # Suggest to use dockerConfigJson if you set overrides here.
+  # Suggest to use dockerConfigJson if you set overrides here,
+  # For example: 
+  # --set-file images.imageCredentials.dockerConfigJson=<your dockerConfigJson file> ,
+  # or set the json context in values.yaml file 
+  # dockerConfigJson: |
+  #   {
+  #     "auths": {
+  #       "<your registry>": {
+  #         "auth": "xxx",
+  #         "email": "xxx"
+  #     }
+  #   }
+  # }
+  #
   # The image pull secret is fixed into the serviceAccount, you can also set
   # `createImageCredentials` to `false` and create the pull secret manually.
   imageCredentials:
@@ -75,11 +88,30 @@ affinity:
 # enableSyncLabels is to enable the feature which can sync the labels from klusterlet to all agent resources.
 enableSyncLabels: false
 
-# should be the kubeConfig file of the hub cluster via setting --set-file=<the kubeConfig file of hub cluster> optional
+# The content of the kubeConfig for the hub cluster. Can be set via --set-file bootstrapHubKubeConfig=<path to hub cluster kubeConfig file>
+# or set the kubeConfig content directly here.
+# bootstrapHubKubeConfig: |
+#   apiVersion: v1
+#   clusters:
+#   - cluster:
+#       certificate-authority-data: xxx
+#       server: <hub apiserver>
+#     name: xx
+#   contexts:
+#   - context:
+#   ...
 bootstrapHubKubeConfig: ""
 
-# grpcConfig includes the information needed to build connect to gRPC server in the bootstrap secret for
-# cluster importing via setting --set-file=<the grpc config file> optional.
+# grpcConfig includes the information needed to build connection to gRPC server in the bootstrap secret for
+# cluster importing. Can be set via --set-file grpcConfig=<path to grpc config file>
+# or set the grpcConfig content directly here.
+# caData is the PEM-encoded certificate authority certificates with base64 encoding for the gRPC server.
+# The default caData can be got on the Hub cluster by `kubectl get configmaps -n open-cluster-management-hub ca-bundle-configmap -o jsonpath='{.data.ca-bundle\.crt}'`.
+# token can be got on the Hub cluster by `clusteradm get token`. 
+# grpcConfig: |
+#   caData: xxx 
+#   token: xxx 
+#   url: <grpc server URL on the Hub cluster> # required
 grpcConfig: ""
 
 # when MultipleHubs feature gate in klusterlet.registrationConfiguration is enabled, could set multiple bootstrap hub kubeConfigs here.
@@ -90,8 +122,8 @@ multiHubBootstrapHubKubeConfigs:
 #  - name: xxx
 #    kubeConfig: xxx
 
-# should be the kubeConfig file of the managed cluster via setting --set-file=<the kubeConfig file of managed cluster>
-# only need to set in the hosted mode. optional
+# The content of the kubeConfig for the managed cluster. Can be set via --set-file externalManagedKubeConfig=<path to managed cluster kubeConfig file>
+# Only needed in Hosted or SingletonHosted mode. Optional.
 externalManagedKubeConfig: ""
 
 # only install the klusterlet CR if set true.

--- a/vendor/open-cluster-management.io/ocm/pkg/operator/helpers/chart/config.go
+++ b/vendor/open-cluster-management.io/ocm/pkg/operator/helpers/chart/config.go
@@ -141,6 +141,10 @@ type ClusterManagerConfig struct {
 	// +optional
 	AddOnManagerConfiguration operatorv1.AddOnManagerConfiguration `json:"addOnManagerConfiguration,omitempty"`
 
+	// ServerConfiguration contains the configuration of http/grpc server.
+	// +optional
+	ServerConfiguration operatorv1.ServerConfiguration `json:"serverConfiguration,omitempty"`
+
 	// ResourceRequirement specify QoS classes of deployments managed by clustermanager.
 	// It applies to all the containers in the deployments.
 	// +optional


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gRPC as a supported registration driver plus init-time options to set the gRPC server address and auto-approved identities.

* **Tests**
  * Updated end-to-end tests to validate gRPC-based cluster initialization, moved config to init-time, and extended polling windows for reliability.

* **Chores**
  * Bumped a dependency version.

* **Style**
  * Clarified user-facing log messages and improved deletion-wait messaging for clearer output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->