### PR TITLE
✨ feat: Add hub-side ManagedCluster cleanup to unjoin command

### DIFF
--- a/pkg/cmd/unjoin/cmd.go
+++ b/pkg/cmd/unjoin/cmd.go
@@ -14,6 +14,9 @@ import (
 var example = `
 # UnJoin a cluster from a hub
 %[1]s unjoin --cluster-name <cluster_name>
+
+# UnJoin and cleanup ManagedCluster from hub
+%[1]s unjoin --cluster-name <cluster_name> --cleanup-hub --hub-kubeconfig <hub_kubeconfig_path>
 `
 
 // NewCmd ...
@@ -46,5 +49,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	cmd.Flags().StringVar(&o.clusterName, "cluster-name", "", "The name of the joining cluster")
 	cmd.Flags().BoolVar(&o.purgeOperator, "purge-operator", true, "Purge the operator")
 	cmd.Flags().StringVar(&o.outputFile, "output-file", "", "The generated resources will be copied in the specified file")
+	cmd.Flags().BoolVar(&o.cleanupHub, "cleanup-hub", false, "Cleanup ManagedCluster resource from hub")
+	cmd.Flags().StringVar(&o.hubKubeconfig, "hub-kubeconfig", "", "Path to hub kubeconfig file (required when --cleanup-hub is enabled)")
 	return cmd
 }

--- a/pkg/cmd/unjoin/options.go
+++ b/pkg/cmd/unjoin/options.go
@@ -17,7 +17,11 @@ type Options struct {
 	purgeOperator bool
 	//The file to output the resources will be sent to the file.
 	outputFile string
-	values     Values
+	//Enable hub-side ManagedCluster cleanup
+	cleanupHub bool
+	//Path to hub kubeconfig file for hub cleanup
+	hubKubeconfig string
+	values        Values
 
 	Streams genericiooptions.IOStreams
 }


### PR DESCRIPTION
## Summary

- Adds optional `--cleanup-hub` flag to delete ManagedCluster CR from hub before managed cluster cleanup
- Adds `--hub-kubeconfig` flag to specify the hub kubeconfig file path
- Implements proper cleanup order: hub deletion → wait for completion → managed cluster cleanup
- Includes progress spinner and configurable timeout (default: 300s) for hub deletion wait
- Fail-fast error handling: stops if hub deletion fails to prevent orphaned resources
- Fully backward compatible: existing behavior unchanged when new flags not used
- Supports dry-run mode

**Usage:**
```bash
# Traditional unjoin (existing behavior)
clusteradm unjoin --cluster-name my-cluster

# Unjoin with hub cleanup
clusteradm unjoin --cluster-name my-cluster --cleanup-hub --hub-kubeconfig /path/to/hub.kubeconfig

# With custom timeout
clusteradm unjoin --cluster-name my-cluster --cleanup-hub --hub-kubeconfig hub.kubeconfig --timeout 600
```

**Implementation Details:**
- Hub deletion happens first to ensure proper cleanup order
- Spinner provides visual feedback during ManagedCluster deletion wait
- Timeout respects global `--timeout` flag (default 300 seconds)
- Gracefully handles already-deleted ManagedClusters
- Follows existing code patterns and error handling conventions

**Bonus fix:** Corrected typo "kluster" → "klusterlet" in error message

## Related issue(s)

N/A - Enhancement based on operational needs for proper cluster decommissioning

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--cleanup-hub` and `--hub-kubeconfig` flags to the unjoin command, enabling streamlined cleanup of managed cluster resources from the hub cluster.

* **Bug Fixes**
  * Fixed wording inconsistency in the appliedManifestWork warning message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->