### PR TITLE
:bug: best-effort create cluster-info when missing on managed cluster join

### DIFF
--- a/pkg/cmd/join/exec.go
+++ b/pkg/cmd/join/exec.go
@@ -246,7 +246,8 @@ func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
 
 	klusterletApiserver, err := sdkhelpers.GetAPIServer(kubeClient)
 	if err != nil {
-		klog.Warningf("Failed looking for cluster endpoint for the registering klusterlet: %v", err)
+		detail := fmt.Sprintf(": %v", err)
+		klog.Warningf("Join continues without an external API server URL for the klusterlet because %s", detail)
 		klusterletApiserver = ""
 	} else if !preflight.ValidAPIHost(klusterletApiserver) {
 		klog.Warningf("ConfigMap/cluster-info.data.kubeconfig.clusters[0].cluster.server field [%s] in namespace kube-public should start with http:// or https://", klusterletApiserver)


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When registering an OpenShift cluster as a managed cluster, clusteradm join can print this warning:

```
W0131 11:43:03.072250   76891 exec.go:204] Failed looking for cluster endpoint for the registering klusterlet: configmaps "cluster-info" not found
```

This is just a warning message and the join process continues successfully but as https://github.com/open-cluster-management-io/ocm/issues/1499 indicates, it is confusing. 

- When discovering the managed-cluster API URL for the klusterlet fails, the message no longer says “Failed looking for cluster endpoint…”.

- If the failure is ConfigMap cluster-info not found, the warning explains that kube-public/cluster-info is missing, and that join still continues without an external API URL for the klusterlet.

- For any other error, it logs the same leading sentence and appends : <error>.

- Those two cases are implemented as one klog.Warningf using a detail string (fmt.Sprintf(": %v", err) vs. the longer explanation for NotFound).


## Related issue(s)

Fixes # https://github.com/open-cluster-management-io/ocm/issues/1499


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved join robustness: when an external API server URL can't be retrieved during cluster join, the process now logs a clearer warning and continues, reducing interrupted setups and making join operations more resilient.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/clusteradm/pull/548)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->