### PR TITLE
✨ cluster-manager Helm values overrides

### DIFF
--- a/pkg/cmd/init/cmd.go
+++ b/pkg/cmd/init/cmd.go
@@ -79,7 +79,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 		"Path to a file containing version bundle overrides. Optional. If provided, overrides component versions within the selected version bundle.")
 	clusterManagerSet.BoolVar(&o.useBootstrapToken, "use-bootstrap-token", false, "If set then the bootstrap token will used instead of a service account token")
 	clusterManagerSet.StringVar(&o.clusterManagerValuesFile, "cluster-manager-values-file", "",
-		"The path to a YAML file containing cluster-manager Helm chart values. The values from the file override both the default chart values and the values from other flags.")
+		"The path to a YAML file containing cluster-manager Helm chart values. The values from the file override both the default chart values and the values from other flags. Does not apply to singleton controlplane.")
 	_ = clusterManagerSet.SetAnnotation("image-registry", "clusterManagerSet", []string{})
 	_ = clusterManagerSet.SetAnnotation("bundle-version", "clusterManagerSet", []string{})
 	_ = clusterManagerSet.SetAnnotation("bundle-version-file", "clusterManagerSet", []string{})

--- a/pkg/cmd/init/cmd.go
+++ b/pkg/cmd/init/cmd.go
@@ -78,10 +78,13 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	cmd.Flags().StringVar(&o.versionBundleFile, "bundle-version-overrides", "",
 		"Path to a file containing version bundle overrides. Optional. If provided, overrides component versions within the selected version bundle.")
 	clusterManagerSet.BoolVar(&o.useBootstrapToken, "use-bootstrap-token", false, "If set then the bootstrap token will used instead of a service account token")
+	clusterManagerSet.StringVar(&o.clusterManagerValuesFile, "cluster-manager-values-file", "",
+		"The path to a YAML file containing cluster-manager Helm chart values. The values from the file override both the default chart values and the values from other flags.")
 	_ = clusterManagerSet.SetAnnotation("image-registry", "clusterManagerSet", []string{})
 	_ = clusterManagerSet.SetAnnotation("bundle-version", "clusterManagerSet", []string{})
 	_ = clusterManagerSet.SetAnnotation("bundle-version-file", "clusterManagerSet", []string{})
 	_ = clusterManagerSet.SetAnnotation("use-bootstrap-token", "clusterManagerSet", []string{})
+	_ = clusterManagerSet.SetAnnotation("cluster-manager-values-file", "clusterManagerSet", []string{})
 	cmd.Flags().AddFlagSet(clusterManagerSet)
 
 	singletonSet := pflag.NewFlagSet("singletonSet", pflag.ExitOnError)

--- a/pkg/cmd/init/exec.go
+++ b/pkg/cmd/init/exec.go
@@ -23,6 +23,7 @@ import (
 	"open-cluster-management.io/clusteradm/pkg/config"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
+	"open-cluster-management.io/clusteradm/pkg/helpers/clustermanager"
 	"open-cluster-management.io/clusteradm/pkg/helpers/helm"
 	clusteradmjson "open-cluster-management.io/clusteradm/pkg/helpers/json"
 	preflightinterface "open-cluster-management.io/clusteradm/pkg/helpers/preflight"
@@ -244,6 +245,12 @@ func (o *Options) run() error {
 			o.clusterManagerChartConfig.CreateBootstrapSA = true
 		} else {
 			o.clusterManagerChartConfig.CreateBootstrapToken = true
+		}
+
+		if o.clusterManagerValuesFile != "" {
+			if err := clustermanager.MergeClusterManagerValues(o.clusterManagerValuesFile, o.clusterManagerChartConfig); err != nil {
+				return fmt.Errorf("failed to merge cluster-manager values file: %w", err)
+			}
 		}
 
 		r := reader.NewResourceReader(o.ClusteradmFlags.KubectlFactory, o.ClusteradmFlags.DryRun, o.Streams)

--- a/pkg/cmd/init/exec.go
+++ b/pkg/cmd/init/exec.go
@@ -253,6 +253,18 @@ func (o *Options) run() error {
 			}
 		}
 
+		// A values file can set both createBootstrapSA and createBootstrapToken to false, which matches the chart
+		// but breaks join token retrieval below (it follows --use-bootstrap-token, not the chart defaults).
+		if !o.ClusteradmFlags.DryRun && !o.clusterManagerChartConfig.CreateBootstrapSA && !o.clusterManagerChartConfig.CreateBootstrapToken {
+			klog.V(1).InfoS("cluster-manager values disabled both bootstrap resources; reapplying bootstrap settings from --use-bootstrap-token for join token retrieval",
+				"useBootstrapToken", o.useBootstrapToken)
+			if !o.useBootstrapToken {
+				o.clusterManagerChartConfig.CreateBootstrapSA = true
+			} else {
+				o.clusterManagerChartConfig.CreateBootstrapToken = true
+			}
+		}
+
 		r := reader.NewResourceReader(o.ClusteradmFlags.KubectlFactory, o.ClusteradmFlags.DryRun, o.Streams)
 		crds, raw, err := chart.RenderClusterManagerChart(
 			context.TODO(),

--- a/pkg/cmd/init/options.go
+++ b/pkg/cmd/init/options.go
@@ -68,6 +68,10 @@ type Options struct {
 	// enableSyncLabels is to enable the feature which can sync the labels from clustermanager to all hub resources.
 	enableSyncLabels bool
 
+	// clusterManagerValuesFile is the path to a YAML file containing cluster-manager Helm chart values.
+	// The values from the file override the default cluster-manager chart values and values from other flags.
+	clusterManagerValuesFile string
+
 	// grpcServer is the gRPC server of the hub.
 	grpcServer string
 	// grpcEndpointType is the type of gRPC server endpoint. The supported types are hostname and loadBalancer.

--- a/pkg/cmd/upgrade/clustermanager/cmd.go
+++ b/pkg/cmd/upgrade/clustermanager/cmd.go
@@ -51,5 +51,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 		"Path to a file containing version bundle overrides. Optional. If provided, overrides component versions within the selected version bundle.")
 	cmd.Flags().BoolVar(&o.wait, "wait", false,
 		"If set, the command will initialize the OCM control plan in foreground.")
+	cmd.Flags().StringVar(&o.clusterManagerValuesFile, "cluster-manager-values-file", "",
+		"The path to a YAML file containing cluster-manager Helm chart values. The values from the file override both the default chart values and the values from other flags.")
 	return cmd
 }

--- a/pkg/cmd/upgrade/clustermanager/exec.go
+++ b/pkg/cmd/upgrade/clustermanager/exec.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	"open-cluster-management.io/clusteradm/pkg/config"
+	"open-cluster-management.io/clusteradm/pkg/helpers/clustermanager"
 	"open-cluster-management.io/clusteradm/pkg/helpers/reader"
 	"open-cluster-management.io/clusteradm/pkg/version"
 	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"
@@ -65,6 +66,12 @@ func (o *Options) complete(_ *cobra.Command, _ []string) (err error) {
 	}
 	if cm.Spec.AddOnManagerConfiguration != nil {
 		o.clusterManagerChartConfig.ClusterManager.AddOnManagerConfiguration = *cm.Spec.AddOnManagerConfiguration
+	}
+
+	if o.clusterManagerValuesFile != "" {
+		if err := clustermanager.MergeClusterManagerValues(o.clusterManagerValuesFile, o.clusterManagerChartConfig); err != nil {
+			return fmt.Errorf("failed to merge cluster-manager values file: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/cmd/upgrade/clustermanager/options.go
+++ b/pkg/cmd/upgrade/clustermanager/options.go
@@ -22,6 +22,10 @@ type Options struct {
 	//If set, the command will hold until the OCM control plane initialized
 	wait bool
 
+	// clusterManagerValuesFile is the path to a YAML file containing cluster-manager Helm chart values.
+	// The values from the file override the default chart values, values reconstructed from the hub, and values from other flags.
+	clusterManagerValuesFile string
+
 	Streams genericiooptions.IOStreams
 }
 

--- a/pkg/helpers/clustermanager/clustermanager.go
+++ b/pkg/helpers/clustermanager/clustermanager.go
@@ -1,0 +1,30 @@
+// Copyright Contributors to the Open Cluster Management project
+package clustermanager
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ghodss/yaml"
+	"k8s.io/klog/v2"
+	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"
+)
+
+// MergeClusterManagerValues merges a values file for the cluster-manager Helm chart into a cluster-manager chart config.
+//
+// The chart config is a combination of default chart values and values set by clusteradm flags,
+// e.g., --image-registry, --resource-limits, --registration-drivers, etc.
+//
+// The values file can contain any subset of cluster-manager chart values. Invalid values are ignored.
+// Valid values override both the default chart values and the values set by flags.
+func MergeClusterManagerValues(clusterManagerValuesFile string, clusterManagerChartConfig *chart.ClusterManagerChartConfig) error {
+	values, err := os.ReadFile(clusterManagerValuesFile)
+	if err != nil {
+		return fmt.Errorf("failed to read cluster-manager values file %s: %v", clusterManagerValuesFile, err)
+	}
+	if err := yaml.Unmarshal(values, clusterManagerChartConfig); err != nil {
+		return fmt.Errorf("failed to unmarshal cluster-manager values: %v", err)
+	}
+	klog.V(2).InfoS("Successfully merged cluster-manager values file into cluster-manager chart config", "file", clusterManagerValuesFile)
+	return nil
+}

--- a/pkg/helpers/clustermanager/clustermanager_test.go
+++ b/pkg/helpers/clustermanager/clustermanager_test.go
@@ -37,6 +37,9 @@ func TestMergeClusterManagerValues(t *testing.T) {
 				if !cfg.EnableSyncLabels {
 					t.Error("EnableSyncLabels: want true")
 				}
+				if !cfg.ClusterManager.Create {
+					t.Error("ClusterManager.Create: want default true preserved (merge into existing config, not replace)")
+				}
 			},
 		},
 		{

--- a/pkg/helpers/clustermanager/clustermanager_test.go
+++ b/pkg/helpers/clustermanager/clustermanager_test.go
@@ -1,0 +1,85 @@
+// Copyright Contributors to the Open Cluster Management project
+package clustermanager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"
+)
+
+func TestMergeClusterManagerValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		prepare func(t *testing.T) string
+		wantErr bool
+		check   func(t *testing.T, cfg *chart.ClusterManagerChartConfig)
+	}{
+		{
+			name: "valid yaml merges into config",
+			prepare: func(t *testing.T) string {
+				t.Helper()
+				p := filepath.Join(t.TempDir(), "cluster-manager-values.yaml")
+				content := "replicaCount: 2\nenableSyncLabels: true\n"
+				if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+					t.Fatalf("write values file: %v", err)
+				}
+				return p
+			},
+			check: func(t *testing.T, cfg *chart.ClusterManagerChartConfig) {
+				t.Helper()
+				if cfg.ReplicaCount != 2 {
+					t.Errorf("ReplicaCount: want 2, got %d", cfg.ReplicaCount)
+				}
+				if !cfg.EnableSyncLabels {
+					t.Error("EnableSyncLabels: want true")
+				}
+			},
+		},
+		{
+			name: "missing file returns error",
+			prepare: func(t *testing.T) string {
+				t.Helper()
+				return "/nonexistent/file.yaml"
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid yaml returns error",
+			prepare: func(t *testing.T) string {
+				t.Helper()
+				p := filepath.Join(t.TempDir(), "invalid-values.yaml")
+				if err := os.WriteFile(p, []byte("invalid: yaml: content: [unclosed"), 0644); err != nil {
+					t.Fatalf("write invalid file: %v", err)
+				}
+				return p
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := tt.prepare(t)
+			cfg := chart.NewDefaultClusterManagerChartConfig()
+
+			err := MergeClusterManagerValues(path, cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("MergeClusterManagerValues: want error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("MergeClusterManagerValues: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, cfg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[comment]: # ( Copyright Contributors to the Open Cluster Management project )

## Summary
Adds cluster-manager Helm chart values overrides for `init` & `clustermanager upgrade`, just like the existing feature for klusterlet values.

## Related issue(s)
See https://github.com/open-cluster-management-io/clusteradm/pull/506

## Fixes #
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line flag enabling users to provide custom cluster-manager configuration through a YAML values file, overriding default Helm chart settings.

* **Tests**
  * Added comprehensive unit tests validating custom values file processing and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->