### PR TITLE
:bug: Use matching bundle version in e2e tests instead of latest

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,6 +64,4 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: E2E Tests
-      run: |
-        BUNDLE_VERSION=$([[ "${{ github.base_ref }}" == "main" ]] && echo latest || echo default) \
-        make test-e2e
+      run: make test-e2e

--- a/test/e2e/e2e-test.mk
+++ b/test/e2e/e2e-test.mk
@@ -7,7 +7,7 @@ export MANAGED_CLUSTER1_NAME := ${PROJECT_NAME}-e2e-test-c1
 export HUB_CTX := kind-${HUB_NAME}
 export MANAGED_CLUSTER1_CTX := kind-${MANAGED_CLUSTER1_NAME}
 
-BUNDLE_VERSION?=latest
+BUNDLE_VERSION := default
 
 clean-e2e: 
 	kind delete cluster --name ${HUB_NAME}


### PR DESCRIPTION
## Summary

Use matching bundle version in e2e tests instead of latest

The e2e CI previously set BUNDLE_VERSION=latest for PRs targeting main, which pulls :latest container images (built from OCM main) but deploys the Helm chart vendored from the Go module dependency (a release tag). This chart-image version mismatch causes spurious RBAC and config failures whenever OCM main introduces chart changes not present in the vendored release, blocking unrelated PRs like version bumps.

The early-detection signal this was meant to provide was inaccurate: it tested a combination (release chart + main images) that no real deployment would ever use, so its failures did not represent real bugs.

Switch to BUNDLE_VERSION=default for all branches so the e2e always tests with a consistent set of chart, images, and compiled code matching the vendored OCM version.

## Related issue(s)

Fixes https://github.com/open-cluster-management-io/clusteradm/issues/552