### PR TITLE
:seedling: chore: adopt shared golangci-lint configuration from sdk-go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ launch.json
 
 # used in e2e test
 config.json
+
+# build output and tools
+_output/

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,11 @@ export GOPACKAGES   = $(shell go list ./... | grep -v /vendor | grep -v /build |
 clean: clean-test clean-e2e
 
 .PHONY: verify
-verify:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.6
-	go vet ./...
-	golangci-lint run --timeout=3m --modules-download-mode vendor -E gofmt ./...
+verify: lint
+
+.PHONY: lint
+lint:
+	@bash -o pipefail -c 'curl -fsSL https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/lint/run-lint.sh | bash'
 
 .PHONY: deps
 deps:

--- a/pkg/clusterprovider/capi/options.go
+++ b/pkg/clusterprovider/capi/options.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
 	"open-cluster-management.io/clusteradm/pkg/clusterprovider"
 )
 

--- a/pkg/cmd/accept/exec.go
+++ b/pkg/cmd/accept/exec.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 )
@@ -34,7 +35,7 @@ const (
 	clusterLabel                     = "open-cluster-management.io/cluster-name"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, _ []string) (err error) {
 	o.Values.Clusters = o.ClusterOptions.AllClusters().UnsortedList()
 	klog.V(1).InfoS("accept options:", "dry-run", o.ClusteradmFlags.DryRun, "clusters", o.Values.Clusters, "wait", o.Wait)
 	return nil
@@ -103,7 +104,7 @@ func (o *Options) accept(kubeClient *kubernetes.Clientset, clusterClient *cluste
 		return false, fmt.Errorf("fail to get managedcluster %s: %v", clusterName, err)
 	}
 	// when a managed cluster registers with hub using awsirsa registration-auth, it will add this annotation
-	// to ManagedCluster resource, presense of which is used to decide the requested authentication type.
+	// to ManagedCluster resource, presence of which is used to decide the requested authentication type.
 	// awrirsa authentication doesn't create CSR on hub, hence there is nothing to approve
 	_, hasEksArn := managedCluster.Annotations["agent.open-cluster-management.io/managed-cluster-arn"]
 

--- a/pkg/cmd/accept/options.go
+++ b/pkg/cmd/accept/options.go
@@ -3,6 +3,7 @@ package accept
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/addon/cmd.go
+++ b/pkg/cmd/addon/cmd.go
@@ -4,6 +4,7 @@ package addon
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"open-cluster-management.io/clusteradm/pkg/cmd/addon/create"
 	"open-cluster-management.io/clusteradm/pkg/cmd/addon/disable"
 	"open-cluster-management.io/clusteradm/pkg/cmd/addon/enable"

--- a/pkg/cmd/addon/create/exec.go
+++ b/pkg/cmd/addon/create/exec.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/resource"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonclientset "open-cluster-management.io/api/client/addon/clientset/versioned"
 	workapiv1 "open-cluster-management.io/api/work/v1"
@@ -127,7 +128,7 @@ func newClusterManagementAddon(o *Options) (*addonv1alpha1.ClusterManagementAddO
 	return cma, nil
 }
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, args []string) (err error) {
 	if len(args) == 0 {
 		return fmt.Errorf("addon name must be specified")
 	}

--- a/pkg/cmd/addon/create/options.go
+++ b/pkg/cmd/addon/create/options.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/utils/ptr"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/addon/disable/exec.go
+++ b/pkg/cmd/addon/disable/exec.go
@@ -13,12 +13,13 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+
 	addonclient "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) error {
+func (o *Options) complete(_ *cobra.Command, _ []string) error {
 	klog.V(1).InfoS("disable options:", "dry-run", o.ClusteradmFlags.DryRun, "names", o.Names, "clusters", o.ClusterOptions.AllClusters())
 
 	return nil
@@ -72,7 +73,7 @@ func (o *Options) Run() (err error) {
 			return err
 		}
 		for _, item := range mcllist.Items {
-			clusters.Insert(item.ObjectMeta.Name)
+			clusters.Insert(item.Name)
 		}
 	} else {
 		clusters = o.ClusterOptions.AllClusters()
@@ -85,10 +86,10 @@ func (o *Options) Run() (err error) {
 
 func (o *Options) runWithClient(clusterClient clusterclientset.Interface,
 	addonClient addonclient.Interface,
-	kubeClient kubernetes.Interface,
-	apiExtensionsClient apiextensionsclient.Interface,
-	dynamicClient dynamic.Interface,
-	dryRun bool,
+	_ kubernetes.Interface,
+	_ apiextensionsclient.Interface,
+	_ dynamic.Interface,
+	_ bool,
 	addons []string,
 	clusters []string) error {
 
@@ -109,9 +110,8 @@ func (o *Options) runWithClient(clusterClient clusterclientset.Interface,
 			if err != nil {
 				if !errors.IsNotFound(err) {
 					return err
-				} else {
-					fmt.Fprintf(o.Streams.Out, "%s add-on not found in cluster: %s.\n", addon, clusterName)
 				}
+				fmt.Fprintf(o.Streams.Out, "%s add-on not found in cluster: %s.\n", addon, clusterName)
 			} else {
 				fmt.Fprintf(o.Streams.Out, "Undeploying %s add-on in managed cluster: %s.\n", addon, clusterName)
 			}

--- a/pkg/cmd/addon/disable/options.go
+++ b/pkg/cmd/addon/disable/options.go
@@ -3,6 +3,7 @@ package disable
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/addon/enable/exec.go
+++ b/pkg/cmd/addon/enable/exec.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"open-cluster-management.io/clusteradm/pkg/helpers/reader"
 	"os"
 	"strings"
+
+	"open-cluster-management.io/clusteradm/pkg/helpers/reader"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -18,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/klog/v2"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonclientset "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
@@ -151,7 +153,7 @@ func NewClusterAddonInfo(cn string, o *Options, an string, configs []addonv1alph
 	}, nil
 }
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, _ []string) (err error) {
 	klog.V(1).InfoS("enable options:", "dry-run", o.ClusteradmFlags.DryRun, "names", o.Names, "clusters", o.ClusterOptions.AllClusters(), "output-file", o.OutputFile)
 
 	return nil

--- a/pkg/cmd/addon/enable/options.go
+++ b/pkg/cmd/addon/enable/options.go
@@ -3,6 +3,7 @@ package enable
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/clean/cmd.go
+++ b/pkg/cmd/clean/cmd.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/clean/exec.go
+++ b/pkg/cmd/clean/exec.go
@@ -5,12 +5,14 @@ package init
 import (
 	"context"
 	"fmt"
+	"log"
+	"time"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/rest"
-	"log"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterapiv1 "open-cluster-management.io/api/cluster/v1"
-	"time"
 
 	"github.com/spf13/cobra"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -21,11 +23,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+
 	clustermanagerclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, _ []string) (err error) {
 	klog.V(1).InfoS("clean options:", "dry-run", o.ClusteradmFlags.DryRun, "output-file", o.OutputFile)
 	o.Values = Values{
 		Hub: Hub{

--- a/pkg/cmd/clean/options.go
+++ b/pkg/cmd/clean/options.go
@@ -4,6 +4,7 @@ package init
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/clusterset/bind/exec.go
+++ b/pkg/cmd/clusterset/bind/exec.go
@@ -8,11 +8,12 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterapiv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, args []string) (err error) {
 	if len(args) == 0 {
 		return fmt.Errorf("the name of the clusterset must be specified")
 	}

--- a/pkg/cmd/clusterset/bind/options.go
+++ b/pkg/cmd/clusterset/bind/options.go
@@ -3,6 +3,7 @@ package bind
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/clusterset/cmd.go
+++ b/pkg/cmd/clusterset/cmd.go
@@ -4,6 +4,7 @@ package clusterset
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"open-cluster-management.io/clusteradm/pkg/cmd/clusterset/bind"
 	"open-cluster-management.io/clusteradm/pkg/cmd/clusterset/set"
 	"open-cluster-management.io/clusteradm/pkg/cmd/clusterset/unbind"

--- a/pkg/cmd/clusterset/set/exec.go
+++ b/pkg/cmd/clusterset/set/exec.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterapiv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, args []string) (err error) {
 	if len(args) == 0 {
 		return fmt.Errorf("the name of the clusterset must be specified")
 	}

--- a/pkg/cmd/clusterset/set/options.go
+++ b/pkg/cmd/clusterset/set/options.go
@@ -3,6 +3,7 @@ package set
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/clusterset/unbind/exec.go
+++ b/pkg/cmd/clusterset/unbind/exec.go
@@ -8,10 +8,11 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, args []string) (err error) {
 	if len(args) == 0 {
 		return fmt.Errorf("the name of the clusterset must be specified")
 	}

--- a/pkg/cmd/clusterset/unbind/options.go
+++ b/pkg/cmd/clusterset/unbind/options.go
@@ -3,6 +3,7 @@ package unbind
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/create/clusterset/exec.go
+++ b/pkg/cmd/create/clusterset/exec.go
@@ -4,13 +4,15 @@ package clusterset
 import (
 	"context"
 	"fmt"
+
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterapiv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, args []string) (err error) {
 	o.Clustersets = args
 
 	return nil

--- a/pkg/cmd/create/clusterset/options.go
+++ b/pkg/cmd/create/clusterset/options.go
@@ -3,6 +3,7 @@ package clusterset
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/create/cmd.go
+++ b/pkg/cmd/create/cmd.go
@@ -4,6 +4,7 @@ package create
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"open-cluster-management.io/clusteradm/pkg/cmd/create/clusterset"
 	"open-cluster-management.io/clusteradm/pkg/cmd/create/placement"
 	"open-cluster-management.io/clusteradm/pkg/cmd/create/sampleapp"

--- a/pkg/cmd/create/placement/exec.go
+++ b/pkg/cmd/create/placement/exec.go
@@ -11,11 +11,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, args []string) (err error) {
 	if len(args) == 0 {
 		return fmt.Errorf("placement name must be specified")
 	}
@@ -142,7 +143,7 @@ func parsePrioritizer(s string) (*clusterv1beta1.PrioritizerConfig, error) {
 		}, nil
 	}
 
-	return nil, fmt.Errorf("unkown prioritizer type %s for %s", ps[0], s)
+	return nil, fmt.Errorf("unknown prioritizer type %s for %s", ps[0], s)
 }
 
 func (o *Options) applyPlacement(clusterClient clusterclientset.Interface, placement *clusterv1beta1.Placement) error {

--- a/pkg/cmd/create/placement/options.go
+++ b/pkg/cmd/create/placement/options.go
@@ -4,6 +4,7 @@ package placement
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/create/sampleapp/exec.go
+++ b/pkg/cmd/create/sampleapp/exec.go
@@ -8,6 +8,7 @@ import (
 	"open-cluster-management.io/clusteradm/pkg/helpers/reader"
 
 	"github.com/spf13/cobra"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	"open-cluster-management.io/clusteradm/pkg/cmd/create/sampleapp/scenario"
 )
@@ -17,7 +18,7 @@ const (
 	pathToAppManifests   = "scenario/sampleapp"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, args []string) (err error) {
 
 	if len(args) > 1 {
 		return fmt.Errorf("only one sample app name can be specified")
@@ -56,7 +57,7 @@ func (o *Options) Run() (err error) {
 	return o.runWithClient(clusterClient, o.ClusteradmFlags.DryRun)
 }
 
-func (o *Options) runWithClient(clusterClient clusterclientset.Interface, dryRun bool) error {
+func (o *Options) runWithClient(_ clusterclientset.Interface, _ bool) error {
 
 	// Apply sample application manifest to hub cluster
 	err := o.deployApp()

--- a/pkg/cmd/create/sampleapp/options.go
+++ b/pkg/cmd/create/sampleapp/options.go
@@ -4,6 +4,7 @@ package sampleapp
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/create/work/exec.go
+++ b/pkg/cmd/create/work/exec.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/resource"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	workclientset "open-cluster-management.io/api/client/work/clientset/versioned"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
@@ -21,7 +22,7 @@ import (
 	clustersdkv1beta1 "open-cluster-management.io/sdk-go/pkg/apis/cluster/v1beta1"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, args []string) (err error) {
 	if len(args) == 0 {
 		return fmt.Errorf("work name must be specified")
 	}

--- a/pkg/cmd/create/work/options.go
+++ b/pkg/cmd/create/work/options.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/utils/ptr"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/delete/clusterset/exec.go
+++ b/pkg/cmd/delete/clusterset/exec.go
@@ -9,11 +9,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, args []string) (err error) {
 
 	o.Clustersets = args
 

--- a/pkg/cmd/delete/clusterset/options.go
+++ b/pkg/cmd/delete/clusterset/options.go
@@ -3,6 +3,7 @@ package clusterset
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/delete/cmd.go
+++ b/pkg/cmd/delete/cmd.go
@@ -4,6 +4,7 @@ package get
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"open-cluster-management.io/clusteradm/pkg/cmd/delete/clusterset"
 	"open-cluster-management.io/clusteradm/pkg/cmd/delete/token"
 	"open-cluster-management.io/clusteradm/pkg/cmd/delete/work"

--- a/pkg/cmd/delete/token/cmd.go
+++ b/pkg/cmd/delete/token/cmd.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/delete/token/exec.go
+++ b/pkg/cmd/delete/token/exec.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
 	"open-cluster-management.io/clusteradm/pkg/config"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 )

--- a/pkg/cmd/delete/token/options.go
+++ b/pkg/cmd/delete/token/options.go
@@ -3,6 +3,7 @@ package token
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 
@@ -12,7 +13,7 @@ type Options struct {
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 }
 
-func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, streams genericiooptions.IOStreams) *Options {
+func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, _ genericiooptions.IOStreams) *Options {
 	return &Options{
 		ClusteradmFlags: clusteradmFlags,
 	}

--- a/pkg/cmd/delete/work/cmd.go
+++ b/pkg/cmd/delete/work/cmd.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/delete/work/exec.go
+++ b/pkg/cmd/delete/work/exec.go
@@ -4,18 +4,20 @@ package work
 import (
 	"context"
 	"fmt"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"time"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+
 	workclientset "open-cluster-management.io/api/client/work/clientset/versioned"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, args []string) (err error) {
 	if len(args) == 0 {
 		return fmt.Errorf("work name must be specified")
 	}
@@ -114,8 +116,8 @@ func (o *Options) deleteWork(workClient *workclientset.Clientset, cluster string
 
 		// if any finalizer exists, remove it.
 		// if not, do nothing and wait for delete event.
-		if len(work.ObjectMeta.Finalizers) != 0 {
-			work.ObjectMeta.Finalizers = work.ObjectMeta.Finalizers[:0]
+		if len(work.Finalizers) != 0 {
+			work.Finalizers = work.Finalizers[:0]
 
 			_, err = workClient.WorkV1().ManifestWorks(cluster).Update(context.TODO(), work, metav1.UpdateOptions{})
 			if err != nil {

--- a/pkg/cmd/delete/work/options.go
+++ b/pkg/cmd/delete/work/options.go
@@ -3,6 +3,7 @@ package work
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/get/addon/exec.go
+++ b/pkg/cmd/get/addon/exec.go
@@ -4,7 +4,9 @@ package addon
 import (
 	"context"
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime"
+
 	workapiv1 "open-cluster-management.io/api/work/v1"
 
 	"github.com/fatih/color"
@@ -13,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonclient "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
@@ -20,7 +23,7 @@ import (
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, args []string) (err error) {
 	o.printer.Competele()
 	klog.V(1).InfoS("addon options:", "dry-run", o.ClusteradmFlags.DryRun, "clusters", o.ClusterOptions.AllClusters().UnsortedList())
 	o.addons = args
@@ -72,7 +75,7 @@ func (o *Options) run() (err error) {
 		}
 
 		for _, item := range mcllist.Items {
-			clusters.Insert(item.ObjectMeta.Name)
+			clusters.Insert(item.Name)
 		}
 	} else {
 		clusters = o.ClusterOptions.AllClusters()

--- a/pkg/cmd/get/addon/options.go
+++ b/pkg/cmd/get/addon/options.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"
 )

--- a/pkg/cmd/get/cluster/exec.go
+++ b/pkg/cmd/get/cluster/exec.go
@@ -9,12 +9,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterapiv1 "open-cluster-management.io/api/cluster/v1"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, _ []string) (err error) {
 	o.printer.Competele()
 
 	return nil

--- a/pkg/cmd/get/cluster/options.go
+++ b/pkg/cmd/get/cluster/options.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"
 )

--- a/pkg/cmd/get/clusterset/exec.go
+++ b/pkg/cmd/get/clusterset/exec.go
@@ -8,19 +8,21 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
+
 	v1 "open-cluster-management.io/api/cluster/v1"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	clusterapiv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"
 	clustersdkv1beta2 "open-cluster-management.io/sdk-go/pkg/apis/cluster/v1beta2"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, _ []string) (err error) {
 	restConfig, err := o.ClusteradmFlags.KubectlFactory.ToRESTConfig()
 	if err != nil {
 		return err

--- a/pkg/cmd/get/clusterset/options.go
+++ b/pkg/cmd/get/clusterset/options.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"

--- a/pkg/cmd/get/cmd.go
+++ b/pkg/cmd/get/cmd.go
@@ -4,6 +4,7 @@ package get
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"open-cluster-management.io/clusteradm/pkg/cmd/get/addon"
 	"open-cluster-management.io/clusteradm/pkg/cmd/get/cluster"
 	"open-cluster-management.io/clusteradm/pkg/cmd/get/clusterset"

--- a/pkg/cmd/get/hubinfo/cmd.go
+++ b/pkg/cmd/get/hubinfo/cmd.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	clusteradmhelpers "open-cluster-management.io/clusteradm/pkg/helpers"
 )

--- a/pkg/cmd/get/hubinfo/exec.go
+++ b/pkg/cmd/get/hubinfo/exec.go
@@ -4,6 +4,7 @@ package hubinfo
 import (
 	"context"
 	"fmt"
+
 	"open-cluster-management.io/api/feature"
 	"open-cluster-management.io/clusteradm/pkg/helpers/check"
 
@@ -12,12 +13,13 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	v1 "open-cluster-management.io/api/operator/v1"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) error {
+func (o *Options) complete(_ *cobra.Command, _ []string) error {
 	cfg, err := o.ClusteradmFlags.KubectlFactory.ToRESTConfig()
 	if err != nil {
 		return err

--- a/pkg/cmd/get/hubinfo/options.go
+++ b/pkg/cmd/get/hubinfo/options.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/kubernetes"
+
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"

--- a/pkg/cmd/get/klusterletinfo/cmd.go
+++ b/pkg/cmd/get/klusterletinfo/cmd.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	clusteradmhelpers "open-cluster-management.io/clusteradm/pkg/helpers"
 )

--- a/pkg/cmd/get/klusterletinfo/exec.go
+++ b/pkg/cmd/get/klusterletinfo/exec.go
@@ -10,12 +10,13 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	v1 "open-cluster-management.io/api/operator/v1"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) error {
+func (o *Options) complete(_ *cobra.Command, _ []string) error {
 	cfg, err := o.ClusteradmFlags.KubectlFactory.ToRESTConfig()
 	if err != nil {
 		return err

--- a/pkg/cmd/get/klusterletinfo/options.go
+++ b/pkg/cmd/get/klusterletinfo/options.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/kubernetes"
+
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"

--- a/pkg/cmd/get/placement/cmd.go
+++ b/pkg/cmd/get/placement/cmd.go
@@ -12,8 +12,8 @@ import (
 )
 
 var example = `
-# Get palcements.
-%[1]s get palcements
+# Get placements.
+%[1]s get placements
 `
 
 // NewCmd...

--- a/pkg/cmd/get/placement/exec.go
+++ b/pkg/cmd/get/placement/exec.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+
 	clusterv1beta1 "open-cluster-management.io/api/client/cluster/clientset/versioned/typed/cluster/v1beta1"
 	"open-cluster-management.io/api/cluster/v1beta1"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"
@@ -18,7 +19,7 @@ import (
 
 const placementLabel = "cluster.open-cluster-management.io/placement"
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, _ []string) (err error) {
 	o.printer.Competele()
 
 	return nil
@@ -96,7 +97,7 @@ func (o *Options) convertToTree(obj runtime.Object, tree *printer.TreePrinter) *
 	// save decisions into a map
 	selectedClusters := make(map[string][]v1beta1.ClusterDecision)
 	for _, decision := range decisionList.Items {
-		placementName := decision.ObjectMeta.Labels[placementLabel]
+		placementName := decision.Labels[placementLabel]
 		selectedClusters[placementName] = decision.Status.Decisions
 	}
 
@@ -111,7 +112,7 @@ func (o *Options) convertToTree(obj runtime.Object, tree *printer.TreePrinter) *
 			mp[".Status.Conditions.PlacementConditionMisconfigured"] = misconfig
 			mp[".PlacementDecision"] = decision
 
-			tree.AddFileds(pla.ObjectMeta.Name, &mp)
+			tree.AddFileds(pla.Name, &mp)
 		}
 	}
 
@@ -139,7 +140,7 @@ func getFileds(placement v1beta1.Placement, selectedClusters map[string][]v1beta
 
 	number = int(placement.Status.NumberOfSelectedClusters)
 
-	clusters, ok := selectedClusters[placement.ObjectMeta.Name]
+	clusters, ok := selectedClusters[placement.Name]
 	if !ok {
 		decision = []string{"NoClusterSelected"}
 	} else {
@@ -148,7 +149,7 @@ func getFileds(placement v1beta1.Placement, selectedClusters map[string][]v1beta
 		}
 	}
 
-	return
+	return namespace, clusterset, satisfied, misconfig, number, decision
 }
 
 func (o *Options) converToTable(obj runtime.Object) *metav1.Table {
@@ -160,7 +161,7 @@ func (o *Options) converToTable(obj runtime.Object) *metav1.Table {
 	// save decisions into a map
 	selectedClusters := make(map[string][]v1beta1.ClusterDecision)
 	for _, decision := range decisionList.Items {
-		placementName := decision.ObjectMeta.Labels[placementLabel]
+		placementName := decision.Labels[placementLabel]
 		selectedClusters[placementName] = decision.Status.Decisions
 	}
 
@@ -176,8 +177,8 @@ func (o *Options) converToTable(obj runtime.Object) *metav1.Table {
 
 	if placementList, ok := obj.(*v1beta1.PlacementList); ok {
 		for _, placement := range placementList.Items {
-			var clusters []string
-			for _, i := range selectedClusters[placement.ObjectMeta.Name] {
+			clusters := make([]string, 0, len(selectedClusters[placement.Name]))
+			for _, i := range selectedClusters[placement.Name] {
 				clusters = append(clusters, i.ClusterName)
 			}
 

--- a/pkg/cmd/get/placement/options.go
+++ b/pkg/cmd/get/placement/options.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
+
 	clusterv1beta1 "open-cluster-management.io/api/client/cluster/clientset/versioned/typed/cluster/v1beta1"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"

--- a/pkg/cmd/get/token/cmd.go
+++ b/pkg/cmd/get/token/cmd.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/get/token/exec.go
+++ b/pkg/cmd/get/token/exec.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 	clusteradmjson "open-cluster-management.io/clusteradm/pkg/helpers/json"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, _ []string) (err error) {
 	o.values = Values{
 		Hub: Hub{
 			TokenID:     helpers.RandStringRunes_az09(6),

--- a/pkg/cmd/get/token/options.go
+++ b/pkg/cmd/get/token/options.go
@@ -3,6 +3,7 @@ package token
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 

--- a/pkg/cmd/get/work/exec.go
+++ b/pkg/cmd/get/work/exec.go
@@ -9,13 +9,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	workclient "open-cluster-management.io/api/client/work/clientset/versioned"
 	workapiv1 "open-cluster-management.io/api/work/v1"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, args []string) (err error) {
 	if len(args) > 1 {
 		return fmt.Errorf("can only specify one manifestwork")
 	}

--- a/pkg/cmd/get/work/options.go
+++ b/pkg/cmd/get/work/options.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"
 )

--- a/pkg/cmd/init/cmd.go
+++ b/pkg/cmd/init/cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 )

--- a/pkg/cmd/init/exec.go
+++ b/pkg/cmd/init/exec.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+
 	ocmfeature "open-cluster-management.io/api/feature"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 	"open-cluster-management.io/clusteradm/pkg/cmd/init/preflight"
@@ -43,7 +44,7 @@ var (
 
 var validRegistrationDriver = sets.New[string](operatorv1.CSRAuthType, operatorv1.AwsIrsaAuthType, operatorv1.GRPCAuthType)
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(cmd *cobra.Command, _ []string) (err error) {
 	klog.V(1).InfoS("init options:", "dry-run", o.ClusteradmFlags.DryRun, "force", o.force, "output-file", o.outputFile)
 
 	// ensure the flags are set correctly

--- a/pkg/cmd/init/options.go
+++ b/pkg/cmd/init/options.go
@@ -3,6 +3,7 @@ package init
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers/helm"
 	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"

--- a/pkg/cmd/init/preflight/checks.go
+++ b/pkg/cmd/init/preflight/checks.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -36,6 +35,7 @@ func (c SingletonControlplaneCheck) Name() string {
 	return "SingletonControlplane check"
 }
 
+//nolint:revive
 type HubApiServerCheck struct {
 	Config clientcmd.ClientConfig
 }
@@ -119,7 +119,7 @@ func (c ClusterInfoCheck) Name() string {
 
 // loadCurrentCluster will load kubeconfig from file and return the current cluster.
 // The default file path is ~/.kube/config.
-func loadCurrentCluster(currentConfig clientcmdapi.Config) (*api.Cluster, error) {
+func loadCurrentCluster(currentConfig clientcmdapi.Config) (*clientcmdapi.Cluster, error) {
 	context := currentConfig.CurrentContext
 	currentCtx, exists := currentConfig.Contexts[context]
 	if !exists {

--- a/pkg/cmd/install/cmd.go
+++ b/pkg/cmd/install/cmd.go
@@ -4,6 +4,7 @@ package install
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	hubaddon "open-cluster-management.io/clusteradm/pkg/cmd/install/hubaddon"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )

--- a/pkg/cmd/install/hubaddon/exec.go
+++ b/pkg/cmd/install/hubaddon/exec.go
@@ -33,7 +33,7 @@ var (
 	policyFrameworkAddonName = "governance-policy-framework"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, _ []string) (err error) {
 	klog.V(1).InfoS("addon options:", "dry-run", o.ClusteradmFlags.DryRun, "names", o.names, "output-file", o.outputFile)
 	return nil
 }
@@ -115,15 +115,15 @@ func (o *Options) runWithClient() error {
 		}
 		err := r.Apply(scenario.Files, o.values, files.CRDFiles...)
 		if err != nil {
-			return fmt.Errorf("Error deploying %s CRDs: %w", addon, err)
+			return fmt.Errorf("error deploying %s CRDs: %w", addon, err)
 		}
 		err = r.Apply(scenario.Files, o.values, files.ConfigFiles...)
 		if err != nil {
-			return fmt.Errorf("Error deploying %s dependencies: %w", addon, err)
+			return fmt.Errorf("error deploying %s dependencies: %w", addon, err)
 		}
 		err = r.Apply(scenario.Files, o.values, files.DeploymentFiles...)
 		if err != nil {
-			return fmt.Errorf("Error deploying %s deployments: %w", addon, err)
+			return fmt.Errorf("error deploying %s deployments: %w", addon, err)
 		}
 
 		fmt.Fprintf(o.Streams.Out, "Installing built-in %s add-on to the Hub cluster...\n", addon)

--- a/pkg/cmd/install/hubaddon/options.go
+++ b/pkg/cmd/install/hubaddon/options.go
@@ -3,6 +3,7 @@ package hubaddon
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"open-cluster-management.io/clusteradm/pkg/cmd/install/hubaddon/scenario"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers/helm"

--- a/pkg/cmd/join/cmd.go
+++ b/pkg/cmd/join/cmd.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers"

--- a/pkg/cmd/join/exec.go
+++ b/pkg/cmd/join/exec.go
@@ -31,6 +31,7 @@ import (
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/util"
+
 	clusterclient "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"

--- a/pkg/cmd/join/options.go
+++ b/pkg/cmd/join/options.go
@@ -4,6 +4,7 @@ package join
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+
 	"open-cluster-management.io/clusteradm/pkg/clusterprovider/capi"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"

--- a/pkg/cmd/join/preflight/checks.go
+++ b/pkg/cmd/join/preflight/checks.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 )
 
@@ -87,7 +88,7 @@ func (c DeployModeCheck) Check() (warningList []string, errorList []error) {
 		if !c.InternalEndpoint {
 			err := helpers.ValidateKubeconfigFile(c.ManagedKubeconfigFile)
 			if err != nil {
-				return nil, []error{errors.New(fmt.Sprintf("validate managed kubeconfig file failed: %v", err))}
+				return nil, []error{fmt.Errorf("validate managed kubeconfig file failed: %v", err)}
 			}
 		}
 	}

--- a/pkg/cmd/proxy/cmd.go
+++ b/pkg/cmd/proxy/cmd.go
@@ -4,6 +4,7 @@ package proxy
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"open-cluster-management.io/clusteradm/pkg/cmd/proxy/health"
 	"open-cluster-management.io/clusteradm/pkg/cmd/proxy/kubectl"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"

--- a/pkg/cmd/proxy/health/exec.go
+++ b/pkg/cmd/proxy/health/exec.go
@@ -28,6 +28,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
+	konnectivity "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
+	proxyutil "sigs.k8s.io/apiserver-network-proxy/pkg/util"
+
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/client/cluster/clientset/versioned/typed/cluster/v1"
@@ -36,11 +39,9 @@ import (
 	"open-cluster-management.io/cluster-proxy/pkg/generated/clientset/versioned"
 	"open-cluster-management.io/cluster-proxy/pkg/util"
 	"open-cluster-management.io/clusteradm/pkg/config"
-	konnectivity "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
-	proxyutil "sigs.k8s.io/apiserver-network-proxy/pkg/util"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) error {
+func (o *Options) complete(_ *cobra.Command, _ []string) error {
 	if len(o.proxyClientCACertPath) > 0 && len(o.proxyClientCertPath) > 0 && len(o.proxyClientKeyPath) > 0 {
 		o.isProxyServerAddressProvided = true
 	}
@@ -253,7 +254,7 @@ func (o *Options) visit(
 	// doesn't sign the managed cluster name into its server certificate's SAN, the
 	// client will be failing due to server hostname validation.
 	// TODO: Securing the proxied requests.
-	copiedCfg.TLSClientConfig.Insecure = true
+	copiedCfg.Insecure = true
 
 	rt, err := rest.TransportFor(copiedCfg)
 	if err != nil {
@@ -284,7 +285,7 @@ func (o *Options) visit(
 
 	end := time.Now()
 	data, _ := io.ReadAll(resp.Body)
-	if "ok" == string(data) {
+	if string(data) == "ok" {
 		health = "True"
 		latency = end.Sub(start).String()
 	}

--- a/pkg/cmd/proxy/health/options.go
+++ b/pkg/cmd/proxy/health/options.go
@@ -3,6 +3,7 @@ package health
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 
@@ -24,7 +25,7 @@ type Options struct {
 	isProxyServerAddressProvided bool
 }
 
-func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, streams genericiooptions.IOStreams) *Options {
+func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, _ genericiooptions.IOStreams) *Options {
 	return &Options{
 		ClusteradmFlags: clusteradmFlags,
 		ClusterOption:   genericclioptionsclusteradm.NewClusterOption().AllowUnset(),

--- a/pkg/cmd/proxy/kubectl/certificates.go
+++ b/pkg/cmd/proxy/kubectl/certificates.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
 	proxyv1alpha1 "open-cluster-management.io/cluster-proxy/pkg/apis/proxy/v1alpha1"
 )
 

--- a/pkg/cmd/proxy/kubectl/cmd.go
+++ b/pkg/cmd/proxy/kubectl/cmd.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
+
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/client/cluster/clientset/versioned/typed/cluster/v1"
 	proxyv1alpha1 "open-cluster-management.io/cluster-proxy/pkg/apis/proxy/v1alpha1"
@@ -107,7 +108,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 			defer portForwardClose()
 
 			// Run a http-proxy-server in goroutine
-			hps, err := newHttpProxyServer(
+			hps, err := newHTTPProxyServer(
 				cmd.Context(),
 				o.ClusterOption.Cluster,
 				int32(8090), // TODO make it configurable or random later
@@ -156,7 +157,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 					// We are using combinedoutput, so err msg should include in result, no need to handle err
 					result, _ := runKubectlCommand(tmpKubeconfigFilePath, strings.TrimRight(input, "\n"))
 					if _, err = streams.Out.Write(result); err != nil {
-						return errors.Wrap(err, "streams out write failed, exist the interactive mode.")
+						return errors.Wrap(err, "streams out write failed, exit the interactive mode")
 					}
 				}
 			} else {

--- a/pkg/cmd/proxy/kubectl/http-proxy-server.go
+++ b/pkg/cmd/proxy/kubectl/http-proxy-server.go
@@ -27,7 +27,7 @@ type httpProxyServer struct {
 	cluster         string
 }
 
-func newHttpProxyServer(
+func newHTTPProxyServer(
 	ctx context.Context,
 	cluster string,
 	proxyServerPort int32,
@@ -143,7 +143,7 @@ func (s *httpProxyServer) handle(wr http.ResponseWriter, req *http.Request) {
 	}
 
 	proxy.ErrorHandler = func(rw http.ResponseWriter, r *http.Request, e error) {
-		_, err = rw.Write([]byte(fmt.Sprintf("proxy to anp-proxy-server failed because %v", e)))
+		_, err = fmt.Fprintf(rw, "proxy to anp-proxy-server failed because %v", e)
 		if err != nil {
 			klog.Errorf("response write fail %v", e)
 			return

--- a/pkg/cmd/proxy/kubectl/options.go
+++ b/pkg/cmd/proxy/kubectl/options.go
@@ -2,8 +2,9 @@
 package kubectl
 
 import (
-	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"sigs.k8s.io/kustomize/kyaml/errors"
+
+	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 
 // Options: only support use in-cluster certificates

--- a/pkg/cmd/uninstall/cmd.go
+++ b/pkg/cmd/uninstall/cmd.go
@@ -4,6 +4,7 @@ package uninstall
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"open-cluster-management.io/clusteradm/pkg/cmd/uninstall/hubaddon"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )

--- a/pkg/cmd/uninstall/hubaddon/exec.go
+++ b/pkg/cmd/uninstall/hubaddon/exec.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	addonclientset "open-cluster-management.io/api/client/addon/clientset/versioned"
 	"open-cluster-management.io/clusteradm/pkg/helpers/reader"
 	"open-cluster-management.io/clusteradm/pkg/version"

--- a/pkg/cmd/uninstall/hubaddon/options.go
+++ b/pkg/cmd/uninstall/hubaddon/options.go
@@ -3,6 +3,7 @@ package hubaddon
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"open-cluster-management.io/clusteradm/pkg/cmd/install/hubaddon/scenario"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers/helm"

--- a/pkg/cmd/unjoin/exec.go
+++ b/pkg/cmd/unjoin/exec.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+
 	klusterletclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	appliedworkclient "open-cluster-management.io/api/client/work/clientset/versioned"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
@@ -29,7 +30,7 @@ const (
 	managedKubeconfigSecretName = "external-managed-kubeconfig"
 )
 
-func (o *Options) complete(cmd *cobra.Command, args []string) (err error) {
+func (o *Options) complete(_ *cobra.Command, _ []string) (err error) {
 	klog.V(1).InfoS("unjoin  options:", "dry-run", o.ClusteradmFlags.DryRun, "cluster", o.clusterName, o.outputFile)
 
 	o.values = Values{
@@ -140,7 +141,7 @@ func (o *Options) run() error {
 
 }
 
-func (o *Options) getKlusterlet(kubeClient kubernetes.Interface, klusterletClient klusterletclient.Interface) error {
+func (o *Options) getKlusterlet(_ kubernetes.Interface, klusterletClient klusterletclient.Interface) error {
 	list, err := klusterletClient.OperatorV1().Klusterlets().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return err

--- a/pkg/cmd/unjoin/options.go
+++ b/pkg/cmd/unjoin/options.go
@@ -3,6 +3,7 @@ package unjoin
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )

--- a/pkg/cmd/upgrade/clustermanager/cmd.go
+++ b/pkg/cmd/upgrade/clustermanager/cmd.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 )

--- a/pkg/cmd/upgrade/clustermanager/exec.go
+++ b/pkg/cmd/upgrade/clustermanager/exec.go
@@ -7,6 +7,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	"open-cluster-management.io/clusteradm/pkg/config"
 	"open-cluster-management.io/clusteradm/pkg/helpers/clustermanager"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
+
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 	"open-cluster-management.io/clusteradm/pkg/helpers/wait"
 )

--- a/pkg/cmd/upgrade/clustermanager/options.go
+++ b/pkg/cmd/upgrade/clustermanager/options.go
@@ -3,6 +3,7 @@ package clustermanager
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"
 )

--- a/pkg/cmd/upgrade/cmd.go
+++ b/pkg/cmd/upgrade/cmd.go
@@ -4,6 +4,7 @@ package upgrade
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	"open-cluster-management.io/clusteradm/pkg/cmd/upgrade/clustermanager"
 	"open-cluster-management.io/clusteradm/pkg/cmd/upgrade/klusterlet"
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"

--- a/pkg/cmd/upgrade/klusterlet/cmd.go
+++ b/pkg/cmd/upgrade/klusterlet/cmd.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 )

--- a/pkg/cmd/upgrade/klusterlet/exec.go
+++ b/pkg/cmd/upgrade/klusterlet/exec.go
@@ -9,6 +9,7 @@ import (
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 
 	"open-cluster-management.io/clusteradm/pkg/config"

--- a/pkg/cmd/upgrade/klusterlet/options.go
+++ b/pkg/cmd/upgrade/klusterlet/options.go
@@ -3,6 +3,7 @@ package klusterlet
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"
 )

--- a/pkg/cmd/version/exec.go
+++ b/pkg/cmd/version/exec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"open-cluster-management.io/clusteradm/pkg/version"
 )
 

--- a/pkg/cmd/version/options.go
+++ b/pkg/cmd/version/options.go
@@ -3,6 +3,7 @@ package version
 
 import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
 	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 
@@ -11,7 +12,7 @@ type Options struct {
 	ClusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags
 }
 
-func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, streams genericiooptions.IOStreams) *Options {
+func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, _ genericiooptions.IOStreams) *Options {
 	return &Options{
 		ClusteradmFlags: clusteradmFlags,
 	}

--- a/pkg/genericclioptions/cluster_flags.go
+++ b/pkg/genericclioptions/cluster_flags.go
@@ -3,6 +3,7 @@ package genericclioptions
 
 import (
 	"fmt"
+
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/sets"
 )

--- a/pkg/genericclioptions/clusteradm_flags.go
+++ b/pkg/genericclioptions/clusteradm_flags.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/pflag"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
 	clusterclientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	"open-cluster-management.io/clusteradm/pkg/helpers/check"
 )
@@ -55,11 +56,11 @@ func (f *ClusteradmFlags) ValidateManagedCluster() error {
 func (f *ClusteradmFlags) buildClusterClientset() (*clusterclientset.Clientset, error) {
 	config, err := f.KubectlFactory.ToRESTConfig()
 	if err != nil {
-		return nil, fmt.Errorf("Build ClusteradmFlags failed: %v", err)
+		return nil, fmt.Errorf("build ClusteradmFlags failed: %v", err)
 	}
 	client, err := clusterclientset.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("Build ClusteradmFlags failed: %v", err)
+		return nil, fmt.Errorf("build ClusteradmFlags failed: %v", err)
 	}
 	return client, nil
 }

--- a/pkg/genericclioptions/feature_gates.go
+++ b/pkg/genericclioptions/feature_gates.go
@@ -4,6 +4,7 @@ package genericclioptions
 import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/featuregate"
+
 	ocmfeature "open-cluster-management.io/api/feature"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 )

--- a/pkg/helpers/check/check.go
+++ b/pkg/helpers/check/check.go
@@ -7,6 +7,7 @@ import (
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	clusterclient "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
@@ -20,6 +21,7 @@ const (
 	ClusterClaimResourceName   = "clusterclaims"
 )
 
+//nolint:revive
 func CheckForHub(client clusterclient.Interface) error {
 	msg := "hub oriented command should not running against non-hub cluster"
 
@@ -39,6 +41,7 @@ func CheckForHub(client clusterclient.Interface) error {
 	return errors.New(msg)
 }
 
+//nolint:revive
 func CheckForKlusterletCRD(client operatorclient.Interface) error {
 	msg := "klusterlet crd not found"
 
@@ -53,6 +56,7 @@ func CheckForKlusterletCRD(client operatorclient.Interface) error {
 	return errors.New(msg)
 }
 
+//nolint:revive
 func CheckForManagedCluster(client clusterclient.Interface) error {
 	msg := "managed cluster oriented command should not running against non-managed cluster"
 

--- a/pkg/helpers/client.go
+++ b/pkg/helpers/client.go
@@ -16,7 +16,6 @@ import (
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -29,6 +28,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/utils/ptr"
+
 	"open-cluster-management.io/clusteradm/pkg/config"
 )
 
@@ -84,9 +84,9 @@ func WaitCRDToBeReady(apiExtensionsClient apiextensionsclient.Interface, name st
 				metav1.GetOptions{})
 		if established := apiextensionshelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established); !established {
 			if wait {
-				fmt.Printf("Wait for %s crd to be established\n", name)
+				fmt.Printf("wait for %s crd to be established\n", name)
 			}
-			return fmt.Errorf("Wait for %s crd to be established", name)
+			return fmt.Errorf("wait for %s crd to be established", name)
 		}
 
 		return err
@@ -190,7 +190,7 @@ func IsClusterManagerInstalled(apiExtensionsClient apiextensionsclient.Interface
 func IsKlusterletsInstalled(apiExtensionsClient apiextensionsclient.Interface) (bool, error) {
 	_, err := apiExtensionsClient.ApiextensionsV1().
 		CustomResourceDefinitions().
-		Get(context.TODO(), "klusterlets.operator.open-cluster-management.io", v1.GetOptions{})
+		Get(context.TODO(), "klusterlets.operator.open-cluster-management.io", metav1.GetOptions{})
 	if err == nil {
 		return true, nil
 	}

--- a/pkg/helpers/clustermanager/clustermanager.go
+++ b/pkg/helpers/clustermanager/clustermanager.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"k8s.io/klog/v2"
+
 	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"
 )
 

--- a/pkg/helpers/helm/helm.go
+++ b/pkg/helpers/helm/helm.go
@@ -73,7 +73,7 @@ func (h *Helm) SetValue(key, value string) {
 }
 
 // PrepareChart prepares the chart for installation
-func (h *Helm) PrepareChart(repoName, repoUrl string) error {
+func (h *Helm) PrepareChart(repoName, repoURL string) error {
 	// add repo
 	repoFile := h.settings.RepositoryConfig
 
@@ -114,7 +114,7 @@ func (h *Helm) PrepareChart(repoName, repoUrl string) error {
 	if !f.Has(repoName) {
 		c := repo.Entry{
 			Name: repoName,
-			URL:  repoUrl,
+			URL:  repoURL,
 		}
 
 		r, err := repo.NewChartRepository(&c, getter.All(h.settings))
@@ -123,7 +123,7 @@ func (h *Helm) PrepareChart(repoName, repoUrl string) error {
 		}
 
 		if _, err := r.DownloadIndexFile(); err != nil {
-			err := errors.Wrapf(err, "looks like %q is not a valid chart repository or cannot be reached", repoUrl)
+			err := errors.Wrapf(err, "looks like %q is not a valid chart repository or cannot be reached", repoURL)
 			log.Fatal(err)
 		}
 
@@ -168,7 +168,7 @@ func (h *Helm) InstallChart(name, repo, chart string) {
 		client.Version = ">0.0.0-0"
 	}
 	client.ReleaseName = name
-	cp, err := client.ChartPathOptions.LocateChart(fmt.Sprintf("%s/%s", repo, chart), h.settings)
+	cp, err := client.LocateChart(fmt.Sprintf("%s/%s", repo, chart), h.settings)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func (h *Helm) InstallChart(name, repo, chart string) {
 				man := &downloader.Manager{
 					Out:              os.Stdout,
 					ChartPath:        cp,
-					Keyring:          client.ChartPathOptions.Keyring,
+					Keyring:          client.Keyring,
 					SkipUpdate:       false,
 					Getters:          p,
 					RepositoryConfig: h.settings.RepositoryConfig,

--- a/pkg/helpers/json/json.go
+++ b/pkg/helpers/json/json.go
@@ -13,6 +13,7 @@ type HubInfo struct {
 	HubApiserver string `json:"hub-apiserver"`
 }
 
+//nolint:revive
 func WriteJsonOutput(w io.Writer, val interface{}) error {
 	b, err := json.Marshal(val)
 	if err != nil {

--- a/pkg/helpers/klusterlet/klusterlet.go
+++ b/pkg/helpers/klusterlet/klusterlet.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"k8s.io/klog/v2"
+
 	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"
 )
 

--- a/pkg/helpers/parse/parse.go
+++ b/pkg/helpers/parse/parse.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+//nolint:revive
 func ParseLabels(labels []string) (map[string]string, error) {
 	labelMap := make(map[string]string)
 	for _, labelString := range labels {

--- a/pkg/helpers/preflight/interface.go
+++ b/pkg/helpers/preflight/interface.go
@@ -27,7 +27,7 @@ func (e *Error) Preflight() bool {
 }
 
 // RunChecks runs each check, display it's check/errors,
-// and once all are processed will exist if any errors occured.
+// and once all are processed will exist if any errors occurred.
 func RunChecks(checks []Checker, ww io.Writer) error {
 	var errsBuffer bytes.Buffer
 	for _, check := range checks {
@@ -37,7 +37,7 @@ func RunChecks(checks []Checker, ww io.Writer) error {
 			_, _ = io.WriteString(ww, fmt.Sprintf("\t[WARNING %s]: %v\n", name, warning))
 		}
 		for _, err := range errs {
-			_, _ = errsBuffer.WriteString(fmt.Sprintf("\t[ERROR %s]: %v\n", name, err.Error()))
+			_, _ = fmt.Fprintf(&errsBuffer, "\t[ERROR %s]: %v\n", name, err.Error())
 		}
 		_, _ = io.WriteString(ww, printCheckResult(name, warnings, errs))
 	}

--- a/pkg/helpers/printer/prefixwriter.go
+++ b/pkg/helpers/printer/prefixwriter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fatih/color"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 )
 
@@ -26,6 +27,8 @@ type PrefixWriter interface {
 }
 
 // Each level has 2 spaces for PrefixWriter
+//
+//nolint:revive
 const (
 	LEVEL_0 = iota
 	LEVEL_1

--- a/pkg/helpers/printer/tree.go
+++ b/pkg/helpers/printer/tree.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
+
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 	workapiv1 "open-cluster-management.io/api/work/v1"
 )

--- a/pkg/helpers/random.go
+++ b/pkg/helpers/random.go
@@ -13,8 +13,10 @@ func init() {
 	r = rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
+//nolint:revive
 var letterRunes_az09 = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 
+//nolint:revive
 func RandStringRunes_az09(n int) string {
 	return randStringRunes(n, letterRunes_az09)
 }

--- a/pkg/helpers/resourcerequirement/resourcerequirement.go
+++ b/pkg/helpers/resourcerequirement/resourcerequirement.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 )
 

--- a/pkg/helpers/wait/wait.go
+++ b/pkg/helpers/wait/wait.go
@@ -18,11 +18,13 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubectl/pkg/cmd/util"
+
 	"open-cluster-management.io/clusteradm/pkg/config"
 	"open-cluster-management.io/clusteradm/pkg/helpers"
 	"open-cluster-management.io/clusteradm/pkg/helpers/printer"
 )
 
+//nolint:revive
 func WaitUntilCRDReady(w io.Writer, apiExtensionsClient apiextensionsclient.Interface, crdName string, wait bool) error {
 	b := retry.DefaultBackoff
 	b.Duration = 200 * time.Millisecond
@@ -36,6 +38,7 @@ func WaitUntilCRDReady(w io.Writer, apiExtensionsClient apiextensionsclient.Inte
 	return helpers.WaitCRDToBeReady(apiExtensionsClient, crdName, b, wait)
 }
 
+//nolint:revive
 func WaitUntilRegistrationOperatorReady(w io.Writer, f util.Factory, timeout int64, appLabel string) error {
 	var restConfig *rest.Config
 	restConfig, err := f.ToRESTConfig()
@@ -88,6 +91,7 @@ func WaitUntilRegistrationOperatorReady(w io.Writer, f util.Factory, timeout int
 		})
 }
 
+//nolint:revive
 func WaitUntilClusterManagerRegistrationReady(w io.Writer, f util.Factory, timeout int64) error {
 	var restConfig *rest.Config
 	restConfig, err := f.ToRESTConfig()
@@ -140,6 +144,7 @@ func WaitUntilClusterManagerRegistrationReady(w io.Writer, f util.Factory, timeo
 		})
 }
 
+//nolint:revive
 func WaitUntilMulticlusterControlplaneReady(w io.Writer, f util.Factory, ns string, timeout int64) error {
 	var restConfig *rest.Config
 	restConfig, err := f.ToRESTConfig()
@@ -191,6 +196,7 @@ func WaitUntilMulticlusterControlplaneReady(w io.Writer, f util.Factory, ns stri
 		})
 }
 
+//nolint:revive
 func WaitUntilMulticlusterControlplaneKubeconfigReady(f util.Factory, ns string, b wait.Backoff) error {
 	var restConfig *rest.Config
 	restConfig, err := f.ToRESTConfig()

--- a/test/e2e/util/clusteradm.go
+++ b/test/e2e/util/clusteradm.go
@@ -111,7 +111,8 @@ func (adm *clusteradm) Result() *HandledOutput {
 }
 
 func newClusteradmCmd(flag bool, handled *HandledOutput, subcommand string, args ...string) error {
-	cmdargs := []string{subcommand}
+	cmdargs := make([]string, 0, 1+len(args))
+	cmdargs = append(cmdargs, subcommand)
 	cmdargs = append(cmdargs, args...)
 	c := exec.Command("clusteradm", cmdargs...)
 

--- a/test/e2e/util/e2econf.go
+++ b/test/e2e/util/e2econf.go
@@ -12,6 +12,7 @@ type TestE2eConfig struct {
 	ClearEnv func() error
 }
 
+//nolint:revive
 func (tec *TestE2eConfig) Cluster() *clusterValues {
 	return tec.values.cv
 }

--- a/test/e2e/util/helper.go
+++ b/test/e2e/util/helper.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"open-cluster-management.io/clusteradm/pkg/version"
 	"os"
 	"time"
+
+	"open-cluster-management.io/clusteradm/pkg/version"
 
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -17,6 +18,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
 	clusterclient "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	operatorclient "open-cluster-management.io/api/client/operator/clientset/versioned"
 	operatorv1 "open-cluster-management.io/api/operator/v1"

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -3,10 +3,11 @@ package util
 
 import (
 	"fmt"
-	"open-cluster-management.io/clusteradm/pkg/config"
 	"os"
 	"path"
 	"path/filepath"
+
+	"open-cluster-management.io/clusteradm/pkg/config"
 )
 
 // PrepareE2eEnvironment will init the e2e environment and join managedcluster1 to hub.

--- a/test/e2e/util/values.go
+++ b/test/e2e/util/values.go
@@ -35,6 +35,6 @@ func (cv *clusterValues) ManagedCluster1() *clusterConfig {
 }
 
 type values struct {
-	// cv stores the clusters infomation
+	// cv stores the clusters information
 	cv *clusterValues
 }


### PR DESCRIPTION
Adopts the shared golangci-lint configuration from sdk-go to standardize lint tooling across OCM repositories.

### Changes

- **Makefile**: Replace `verify` target with `lint` target using shared `run-lint.sh` from sdk-go; add `.PHONY: verify`
- **Add `_output/` to `.gitignore`**
- **Use `_` for unused `cmd`/`args` parameters** in cobra `complete()` methods across 26 command files
- **Lint fixes across the codebase**:
  - Fix import grouping (`goimports`) to properly separate `open-cluster-management.io` local imports
  - Add `//nolint:revive` for exported API names that cannot be renamed without breaking changes (`WaitUntil*`, `CheckFor*`, `ParseLabels`, `WriteJsonOutput`, `RandStringRunes_az09`, `HubApiServerCheck`, `LEVEL_*` constants)
  - Fix duplicate imports, lowercase error strings, replace deprecated `errors.New(fmt.Sprintf(...))` with `fmt.Errorf`
  - Fix spelling in comments
  - Refactor naked return
  - Preallocate slices with known capacity

Part of ongoing standardization of lint tooling across OCM repositories.

Also to standardize and automatically pickup the new linter when we move to golang 1.26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling errors in command help text and error messages.
  * Fixed cluster field access in work deletion and placement operations for proper resource handling.
  * Updated kubeconfig cluster data typing in preflight validation.

* **Chores**
  * Reorganized imports and formatting across codebase for consistency.
  * Added build output directory to `.gitignore`.
  * Refactored linting infrastructure and standardized code quality checks.
  * Improved parameter usage clarity in internal methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->