### PR TITLE
:seedling: chore: upgrade to go 1.26

### DIFF
--- a/.github/workflows/ocm.yml
+++ b/.github/workflows/ocm.yml
@@ -5,7 +5,7 @@ on:
     repository_dispatch:
         types: [ocm_changes]
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
     e2e-test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 name: Create Release
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 jobs:
   build:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ on:
     branches: [ main, release-* ]
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   verify:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/clusteradm
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/briandowns/spinner v1.23.0


### PR DESCRIPTION
Upgrades Go version from 1.25 to 1.26.

Changes:
- `go.mod` — go directive updated to 1.26.0
- `.github/workflows/tests.yaml` — GO_VERSION updated to 1.26
- `.github/workflows/release.yaml` — GO_VERSION updated to 1.26
- `.github/workflows/ocm.yml` — GO_VERSION updated to 1.26

Relates to: https://github.com/open-cluster-management-io/ocm/issues/1555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.25 to 1.26 across all build and deployment pipelines to ensure compatibility with the latest Go release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->