### PR TITLE
:seedling: chore: update GRC permissions

### DIFF
--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/addon-controller_clusterrole.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/addon-controller_clusterrole.yaml
@@ -9,17 +9,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - events
-    verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
       - pods
     verbs:
       - get
@@ -34,6 +23,18 @@ rules:
     verbs:
       - get
       - list
+      - watch
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - addon.open-cluster-management.io

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/addon-controller_role.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/addon-controller_role.yaml
@@ -21,6 +21,7 @@ rules:
       - delete
   - apiGroups:
       - ""
+      - events.k8s.io
     resources:
       - events
     verbs:

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_clusterrole.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_clusterrole.yaml
@@ -6,18 +6,6 @@ metadata:
 rules:
   - apiGroups:
       - ""
-    resources:
-      - events
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
     resourceNames:
       - policy-encryption-key
     resources:
@@ -35,9 +23,22 @@ rules:
     verbs:
       - create
   - apiGroups:
-      - "*"
+      - ""
+      - events.k8s.io
     resources:
-      - "*"
+      - events
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
     verbs:
       - get
       - list
@@ -51,9 +52,15 @@ rules:
       - list
       - watch
   - apiGroups:
-      - authorization.k8s.io
+      - authentication.k8s.io
     resources:
       - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
     verbs:
       - create
   - apiGroups:

--- a/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_role.yaml
+++ b/pkg/cmd/install/hubaddon/scenario/addon/policy/propagator_role.yaml
@@ -19,6 +19,7 @@ rules:
   - delete
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:


### PR DESCRIPTION
Sync from:
- https://github.com/open-cluster-management-io/governance-policy-propagator/pull/324
- https://github.com/open-cluster-management-io/governance-policy-addon-controller/pull/290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Kubernetes RBAC for the policy add-on controller with more precise access to pods, named secrets, and events.
  * Updated event handling permissions to use the correct `events.k8s.io` API group and aligned supported verbs.
  * Expanded leader-election RBAC to include the relevant event API group.
  * Adjusted governance policy propagator RBAC, including token review API group mapping and event permission scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->