### PR TITLE
:bug: fix: propagate `clusteradm` flags into Helm at initialization time

### DIFF
--- a/pkg/cmd/init/exec.go
+++ b/pkg/cmd/init/exec.go
@@ -410,10 +410,6 @@ func (o *Options) deploySingletonControlplane(kubeClient kubernetes.Interface) e
 		return err
 	}
 
-	if o.ClusteradmFlags.DryRun {
-		o.Helm.SetValue("dryRun", "true")
-	}
-
 	o.Helm.InstallChart(releaseName, repoName, chartName)
 
 	// fetch the kubeconfig and get the token

--- a/pkg/cmd/init/options.go
+++ b/pkg/cmd/init/options.go
@@ -87,6 +87,6 @@ func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, st
 		ClusteradmFlags:           clusteradmFlags,
 		clusterManagerChartConfig: chart.NewDefaultClusterManagerChartConfig(),
 		Streams:                   streams,
-		Helm:                      helm.NewHelm(),
+		Helm:                      helm.NewHelm(clusteradmFlags),
 	}
 }

--- a/pkg/cmd/install/hubaddon/exec.go
+++ b/pkg/cmd/install/hubaddon/exec.go
@@ -170,15 +170,13 @@ func (o *Options) createNamespace() error {
 }
 
 func (o *Options) runWithHelmClient(addon string) error {
+	o.Helm.WithCreateNamespace(o.values.CreateNamespace)
+
 	if addon == argocdAddonName {
 		o.Helm.WithNamespace(argocdNamespace)
-		o.Helm.WithCreateNamespace(o.values.CreateNamespace)
+
 		if err := o.Helm.PrepareChart(repoName, url); err != nil {
 			return err
-		}
-
-		if o.ClusteradmFlags.DryRun {
-			o.Helm.SetValue("dryRun", "true")
 		}
 
 		o.Helm.InstallChart(argocdReleaseName, repoName, argocdChartName)
@@ -186,13 +184,9 @@ func (o *Options) runWithHelmClient(addon string) error {
 
 	if addon == argocdAgentAddonName {
 		o.Helm.WithNamespace(argocdNamespace)
-		o.Helm.WithCreateNamespace(o.values.CreateNamespace)
+
 		if err := o.Helm.PrepareChart(repoName, url); err != nil {
 			return err
-		}
-
-		if o.ClusteradmFlags.DryRun {
-			o.Helm.SetValue("dryRun", "true")
 		}
 
 		o.Helm.InstallChart(argocdAgentReleaseName, repoName, argocdAgentChartName)

--- a/pkg/cmd/install/hubaddon/exec_test.go
+++ b/pkg/cmd/install/hubaddon/exec_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"open-cluster-management.io/clusteradm/pkg/cmd/install/hubaddon/scenario"
+	"open-cluster-management.io/clusteradm/pkg/helpers/helm"
 	"open-cluster-management.io/clusteradm/pkg/version"
 )
 
@@ -105,6 +106,29 @@ var _ = ginkgo.Describe("install hub-addon", func() {
 			err := o.runWithClient()
 			gomega.Expect(err).Should(gomega.HaveOccurred())
 		})
+	})
+
+	ginkgo.It("Should not create any built-in add-on deployment(s) in dry-run mode", func(ctx ginkgo.SpecContext) {
+		addon := "argocd"
+		clusteradmFlagsCopy := *clusteradmFlags
+		clusteradmFlagsCopy.DryRun = true
+		o := Options{
+			ClusteradmFlags: &clusteradmFlagsCopy,
+			values: scenario.Values{
+				CreateNamespace: true,
+				HubAddons:       []string{addon},
+			},
+			Streams: genericiooptions.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
+			Helm:    helm.NewHelm(&clusteradmFlagsCopy),
+		}
+
+		err := o.runWithHelmClient(addon)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		gomega.Consistently(func(g gomega.Gomega) bool {
+			_, err := kubeClient.CoreV1().Namespaces().Get(ctx, addon, metav1.GetOptions{})
+			return errors.IsNotFound(err)
+		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue(), addon+" namespace should not be created")
 	})
 
 	// Generate entries for the `runWithClient` test table

--- a/pkg/cmd/install/hubaddon/options.go
+++ b/pkg/cmd/install/hubaddon/options.go
@@ -30,6 +30,6 @@ func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, st
 	return &Options{
 		ClusteradmFlags: clusteradmFlags,
 		Streams:         streams,
-		Helm:            helm.NewHelm(),
+		Helm:            helm.NewHelm(clusteradmFlags),
 	}
 }

--- a/pkg/cmd/install/hubaddon/suite_test.go
+++ b/pkg/cmd/install/hubaddon/suite_test.go
@@ -48,10 +48,15 @@ func TestIntegrationInstallAddons(t *testing.T) {
 var _ = ginkgo.BeforeSuite(func() {
 	ginkgo.By("bootstrapping test environment")
 
+	ocmVendorPath := filepath.Join("..", "..", "..", "..", "vendor", "open-cluster-management.io", "api")
+
 	// start a kube-apiserver
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "..", "..", "vendor", "open-cluster-management.io", "api", "addon", "v1alpha1"),
+			filepath.Join(ocmVendorPath, "addon", "v1alpha1"),
+			filepath.Join(ocmVendorPath, "cluster", "v1"),
+			filepath.Join(ocmVendorPath, "cluster", "v1beta1"),
+			filepath.Join(ocmVendorPath, "cluster", "v1beta2"),
 		},
 	}
 

--- a/pkg/cmd/uninstall/hubaddon/options.go
+++ b/pkg/cmd/uninstall/hubaddon/options.go
@@ -26,6 +26,6 @@ func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, st
 	return &Options{
 		ClusteradmFlags: clusteradmFlags,
 		Streams:         streams,
-		Helm:            helm.NewHelm(),
+		Helm:            helm.NewHelm(clusteradmFlags),
 	}
 }

--- a/pkg/helpers/helm/helm.go
+++ b/pkg/helpers/helm/helm.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v2"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/gofrs/flock"
 	"github.com/pkg/errors"
@@ -24,25 +25,38 @@ import (
 	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/repo"
+
+	genericclioptionsclusteradm "open-cluster-management.io/clusteradm/pkg/genericclioptions"
 )
 
 const HelmFlagSetAnnotation = "HelmSet"
 
 type Helm struct {
-	settings        *cli.EnvSettings
-	values          *values.Options
-	createNamespace bool
+	settings         *cli.EnvSettings
+	values           *values.Options
+	createNamespace  bool
+	dryRun           bool
+	restClientGetter genericclioptions.RESTClientGetter
 }
 
-func NewHelm() *Helm {
+func NewHelm(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags) *Helm {
 	h := &Helm{
 		settings: cli.New(),
 		values: &values.Options{
 			Values:     []string{},
 			FileValues: []string{},
 		},
+		dryRun:           clusteradmFlags.DryRun,
+		restClientGetter: clusteradmFlags.KubectlFactory,
 	}
 	return h
+}
+
+func (h *Helm) restClientGetterOrDefault() genericclioptions.RESTClientGetter {
+	if h.restClientGetter != nil {
+		return h.restClientGetter
+	}
+	return h.settings.RESTClientGetter()
 }
 
 func (h *Helm) WithNamespace(ns string) {
@@ -158,11 +172,12 @@ func (h *Helm) PrepareChart(repoName, repoURL string) error {
 // InstallChart installs the chart
 func (h *Helm) InstallChart(name, repo, chart string) {
 	actionConfig := new(action.Configuration)
-	if err := actionConfig.Init(h.settings.RESTClientGetter(), h.settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
+	if err := actionConfig.Init(h.restClientGetterOrDefault(), h.settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
 		log.Fatal(err)
 	}
 	client := action.NewInstall(actionConfig)
 	client.CreateNamespace = h.createNamespace
+	client.DryRun = h.dryRun
 
 	if client.Version == "" && client.Devel {
 		client.Version = ">0.0.0-0"
@@ -221,7 +236,10 @@ func (h *Helm) InstallChart(name, repo, chart string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(release.Manifest)
+
+	if h.dryRun {
+		fmt.Println(release.Manifest)
+	}
 }
 
 func isChartInstallable(ch *chart.Chart) (bool, error) {
@@ -239,7 +257,7 @@ func debug(format string, v ...interface{}) {
 
 func (h *Helm) UninstallRelease(name string) error {
 	actionConfig := new(action.Configuration)
-	if err := actionConfig.Init(h.settings.RESTClientGetter(), h.settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
+	if err := actionConfig.Init(h.restClientGetterOrDefault(), h.settings.Namespace(), os.Getenv("HELM_DRIVER"), debug); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Previously this was setting the `dryRun` in the `values.yaml`, which was not propagating to the Helm logic. This also adds logic to not print manifests outside of the dry run.

This also places manifest printing behind the dry run conditional to reduce noise.

Closes #561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm dry-run handling so it’s applied consistently across install flows.
  * Reduced dry-run output noise by showing Helm release manifests only during dry-run.
  * Applied namespace-creation behavior once per installation to avoid inconsistent results.
* **Tests**
  * Added an integration test verifying dry-run hub add-on install does not create the target namespace.
  * Expanded integration CRD test paths to cover additional CRD versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->