### PR TITLE
:sparkles: feat: add `raw` option for token fetch

### DIFF
--- a/pkg/cmd/get/token/cmd.go
+++ b/pkg/cmd/get/token/cmd.go
@@ -46,7 +46,7 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 
 	cmd.Flags().StringVar(&o.outputFile, "output-file", "", "The generated resources will be copied in the specified file")
 	cmd.Flags().BoolVar(&o.useBootstrapToken, "use-bootstrap-token", false, "If set then the bootstrap token will used instead of a service account token")
-	cmd.Flags().StringVarP(&o.output, "output", "o", "text", "output should be json or text")
+	cmd.Flags().StringVarP(&o.output, "output", "o", "text", "output should be json, text, or raw")
 
 	return cmd
 }

--- a/pkg/cmd/get/token/exec.go
+++ b/pkg/cmd/get/token/exec.go
@@ -66,7 +66,9 @@ func (o *Options) writeResult(token, host string) error {
 		fmt.Println(o.Streams.Out, "token doesn't exist")
 		return nil
 	}
-	if o.output == "json" {
+
+	switch o.output {
+	case "json":
 		err := clusteradmjson.WriteJsonOutput(o.Streams.Out, clusteradmjson.HubInfo{
 			HubToken:     token,
 			HubApiserver: host,
@@ -74,9 +76,14 @@ func (o *Options) writeResult(token, host string) error {
 		if err != nil {
 			return err
 		}
-	} else {
+	case "text":
 		fmt.Fprintf(o.Streams.Out, "token=%s\n", token)
 		fmt.Fprintf(o.Streams.Out, "please log on spoke and run:\n%s join --hub-token %s --hub-apiserver %s --cluster-name <cluster_name>\n", helpers.GetExampleHeader(), token, host)
+	case "raw":
+		fmt.Fprintf(o.Streams.Out, "%s\n", token)
+	default:
+		return fmt.Errorf("invalid output format: %s", o.output)
 	}
+
 	return nil
 }

--- a/pkg/cmd/get/token/exec.go
+++ b/pkg/cmd/get/token/exec.go
@@ -63,8 +63,7 @@ func (o *Options) run() error {
 
 func (o *Options) writeResult(token, host string) error {
 	if len(token) == 0 {
-		fmt.Println(o.Streams.Out, "token doesn't exist")
-		return nil
+		return fmt.Errorf("error: returned token is empty")
 	}
 
 	switch o.output {
@@ -80,7 +79,7 @@ func (o *Options) writeResult(token, host string) error {
 		fmt.Fprintf(o.Streams.Out, "token=%s\n", token)
 		fmt.Fprintf(o.Streams.Out, "please log on spoke and run:\n%s join --hub-token %s --hub-apiserver %s --cluster-name <cluster_name>\n", helpers.GetExampleHeader(), token, host)
 	case "raw":
-		fmt.Fprintf(o.Streams.Out, "%s\n", token)
+		fmt.Fprint(o.Streams.Out, token)
 	default:
 		return fmt.Errorf("invalid output format: %s", o.output)
 	}


### PR DESCRIPTION
Adds an option to print only the token when running `get token`

Closes #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `raw` as an accepted `--output` option for the token command.
  * Updated `--output` help text to list `json`, `text`, and `raw`.
* **Bug Fixes**
  * Token output now matches the selected format precisely (`json`, `text`, or `raw`).
  * Empty tokens now return an error instead of silently printing “token doesn’t exist”.
  * Invalid `--output` values now return an error instead of falling back to text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->