### PR TITLE
:seedling: Test flow tweaks

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   fossa-scan:
     runs-on: ubuntu-latest
@@ -14,6 +17,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+        with:
+          persist-credentials: false
       - name: Run FOSSA Scan
         uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c #v2
         with:

--- a/.github/workflows/ocm.yml
+++ b/.github/workflows/ocm.yml
@@ -12,8 +12,10 @@ jobs:
     e2e-test:
         runs-on: ubuntu-latest
         steps:
-        - run: echo ${{ github.event.client_payload.ref }}
-        - run: echo ${{ github.event.client_payload.sha }}
+        - name: Git Ref ${{ github.event.client_payload.ref }}
+          run: ":"
+        - name: Git SHA ${{ github.event.client_payload.sha }}
+          run: ":"
         - name: Check out code
           uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
           with:

--- a/.github/workflows/ocm.yml
+++ b/.github/workflows/ocm.yml
@@ -5,6 +5,9 @@ on:
     repository_dispatch:
         types: [ocm_changes]
 
+permissions:
+  contents: read
+
 jobs:
     e2e-test:
         runs-on: ubuntu-latest
@@ -13,6 +16,8 @@ jobs:
         - run: echo ${{ github.event.client_payload.sha }}
         - name: Check out code
           uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+          with:
+            persist-credentials: false
         - name: Set up Go
           uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7
           with:

--- a/.github/workflows/ocm.yml
+++ b/.github/workflows/ocm.yml
@@ -4,8 +4,6 @@ name: OCM
 on:
     repository_dispatch:
         types: [ocm_changes]
-env:
-  GO_VERSION: '1.26'
 
 jobs:
     e2e-test:
@@ -13,10 +11,11 @@ jobs:
         steps:
         - run: echo ${{ github.event.client_payload.ref }}
         - run: echo ${{ github.event.client_payload.sha }}
-        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+        - name: Check out code
+          uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
         - name: Set up Go
           uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7
           with:
-            go-version: ${{ env.GO_VERSION }}
+            go-version-file: go.mod
         - name: E2E Tests
           run: make test-e2e

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,9 +8,6 @@ on:
 
 name: Create Release
 
-env:
-  GO_VERSION: "1.26"
-
 jobs:
   build:
     name: Create Release
@@ -21,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: Build project
         run: |
           make build-bin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,16 @@
 # Copyright Contributors to the Open Cluster Management project
 
+name: Create Release
+
 on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
-name: Create Release
-
+permissions:
+  contents: write
+ 
 jobs:
   build:
     name: Create Release
@@ -15,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,11 +8,17 @@ on:
   pull_request:
     branches: [ main, release-* ]
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7
         with:
@@ -26,7 +32,9 @@ jobs:
       GOPATH: /tmp/go
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+      with:
+        persist-credentials: false
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7
       with:
@@ -44,6 +52,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+      with:
+        persist-credentials: false
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7
       with:
@@ -56,6 +66,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+      with:
+        persist-credentials: false
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7
       with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,9 +8,6 @@ on:
   pull_request:
     branches: [ main, release-* ]
 
-env:
-  GO_VERSION: '1.26'
-
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -19,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: verify
         run: make verify
 
@@ -28,16 +25,14 @@ jobs:
     env:
       GOPATH: /tmp/go
     steps:
+    - name: Check out code
+      uses: actions/checkout@v3
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
     - name: Create GOPATH src directory
       run: mkdir -p $GOPATH/src/github.com/open-cluster-management
-    - name: Check out code
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
-      with:
-        fetch-depth: 1
     - name: Copy the code into the GOPATH
       run: cp -r . $GOPATH/src/github.com/open-cluster-management/clusteradm
     - name: Unit Tests
@@ -47,22 +42,24 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+    - name: Check out code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
     - name: Integration Tests
       run: make test-integration
   
   e2e-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+    - name: Check out code
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
     - name: Set up Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
     - name: E2E Tests
       run: |
         BUNDLE_VERSION=$([[ "${{ github.base_ref }}" == "main" ]] && echo latest || echo default) \

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ check-copyright:
 
 .PHONY: test
 test: deps envtest-setup
-	@build/run-unit-tests.sh
+	@KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" build/run-unit-tests.sh
 
 .PHONY: clean-test
 clean-test: 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ GOPATH := ${shell go env GOPATH}
 GOOS := ${shell go env GOOS}
 GOARCH := ${shell go env GOARCH}
 
+LOCAL_BIN := $(PWD)/_output/tools/bin
+export PATH := $(LOCAL_BIN):$(PATH)
+
 SOURCE_GIT_LATEST_TAG ?= $(shell git describe --tags `git rev-list --tags --max-count=1`)
 SOURCE_GIT_TAG ?=$(shell git describe --long --tags --abbrev=7 --match 'v[0-9]*' || echo 'v0.0.0-unknown-$(SOURCE_GIT_COMMIT)')
 SOURCE_GIT_COMMIT ?=$(shell git rev-parse --short "HEAD^{commit}" 2>/dev/null)

--- a/pkg/cmd/init/options.go
+++ b/pkg/cmd/init/options.go
@@ -87,6 +87,6 @@ func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, st
 		ClusteradmFlags:           clusteradmFlags,
 		clusterManagerChartConfig: chart.NewDefaultClusterManagerChartConfig(),
 		Streams:                   streams,
-		Helm:                      helm.NewHelm(clusteradmFlags),
+		Helm:                      helm.NewHelm(clusteradmFlags, streams),
 	}
 }

--- a/pkg/cmd/install/hubaddon/exec_test.go
+++ b/pkg/cmd/install/hubaddon/exec_test.go
@@ -3,6 +3,7 @@ package hubaddon
 
 import (
 	"context"
+	"io"
 	"os"
 
 	"github.com/onsi/ginkgo/v2"
@@ -112,14 +113,15 @@ var _ = ginkgo.Describe("install hub-addon", func() {
 		addon := "argocd"
 		clusteradmFlagsCopy := *clusteradmFlags
 		clusteradmFlagsCopy.DryRun = true
+		streams := genericiooptions.IOStreams{Out: io.Discard, ErrOut: os.Stderr}
 		o := Options{
 			ClusteradmFlags: &clusteradmFlagsCopy,
 			values: scenario.Values{
 				CreateNamespace: true,
 				HubAddons:       []string{addon},
 			},
-			Streams: genericiooptions.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
-			Helm:    helm.NewHelm(&clusteradmFlagsCopy),
+			Streams: streams,
+			Helm:    helm.NewHelm(&clusteradmFlagsCopy, streams),
 		}
 
 		err := o.runWithHelmClient(addon)

--- a/pkg/cmd/install/hubaddon/options.go
+++ b/pkg/cmd/install/hubaddon/options.go
@@ -30,6 +30,6 @@ func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, st
 	return &Options{
 		ClusteradmFlags: clusteradmFlags,
 		Streams:         streams,
-		Helm:            helm.NewHelm(clusteradmFlags),
+		Helm:            helm.NewHelm(clusteradmFlags, streams),
 	}
 }

--- a/pkg/cmd/join/preflight/checks.go
+++ b/pkg/cmd/join/preflight/checks.go
@@ -51,14 +51,15 @@ func (c HubKubeconfigCheck) Check() (warningList []string, errorList []error) {
 	}
 
 	apiResourceList, err := discoveryClient.ServerResourcesForGroupVersion("cluster.open-cluster-management.io/v1")
-	var errs []error
 	if err != nil {
-		errs = append(errs, err)
+		return nil, []error{err}
 	}
+
 	if len(apiResourceList.APIResources) == 0 {
-		errs = append(errs, fmt.Errorf("no apigroup cluster.open-cluster-management.io/v1 detected"))
+		return nil, []error{fmt.Errorf("no apigroup cluster.open-cluster-management.io/v1 detected")}
 	}
-	return nil, errs
+
+	return nil, nil
 }
 
 func (c HubKubeconfigCheck) Name() string {

--- a/pkg/cmd/uninstall/hubaddon/options.go
+++ b/pkg/cmd/uninstall/hubaddon/options.go
@@ -26,6 +26,6 @@ func newOptions(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, st
 	return &Options{
 		ClusteradmFlags: clusteradmFlags,
 		Streams:         streams,
-		Helm:            helm.NewHelm(clusteradmFlags),
+		Helm:            helm.NewHelm(clusteradmFlags, streams),
 	}
 }

--- a/pkg/helpers/helm/helm.go
+++ b/pkg/helpers/helm/helm.go
@@ -12,6 +12,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 
 	"github.com/gofrs/flock"
 	"github.com/pkg/errors"
@@ -37,9 +38,10 @@ type Helm struct {
 	createNamespace  bool
 	clusteradmFlags  *genericclioptionsclusteradm.ClusteradmFlags
 	restClientGetter genericclioptions.RESTClientGetter
+	streams          genericiooptions.IOStreams
 }
 
-func NewHelm(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags) *Helm {
+func NewHelm(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, streams genericiooptions.IOStreams) *Helm {
 	h := &Helm{
 		settings: cli.New(),
 		values: &values.Options{
@@ -48,6 +50,7 @@ func NewHelm(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags) *Helm
 		},
 		clusteradmFlags:  clusteradmFlags,
 		restClientGetter: clusteradmFlags.KubectlFactory,
+		streams:          streams,
 	}
 	return h
 }
@@ -146,7 +149,7 @@ func (h *Helm) PrepareChart(repoName, repoURL string) error {
 		if err := f.WriteFile(repoFile, 0644); err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("%q has been added to your repositories\n", repoName)
+		fmt.Fprintf(h.streams.Out, "%q has been added to your repositories\n", repoName)
 	}
 
 	// update repo
@@ -160,12 +163,12 @@ func (h *Helm) PrepareChart(repoName, repoURL string) error {
 			ocmRepo = r
 		}
 	}
-	fmt.Printf("Hang tight while we grab the latest from ocm chart repository...\n")
+	fmt.Fprintln(h.streams.Out, "Hang tight while we grab the latest from ocm chart repository...")
 
 	if _, err := ocmRepo.DownloadIndexFile(); err != nil {
 		return fmt.Errorf("unable to get an update from the %q chart repository (%s):\n\t%s", ocmRepo.Config.Name, ocmRepo.Config.URL, err)
 	}
-	fmt.Printf("Successfully got an update from the %q chart repository\n", ocmRepo.Config.Name)
+	fmt.Fprintf(h.streams.Out, "Successfully got an update from the %q chart repository\n", ocmRepo.Config.Name)
 	return nil
 }
 
@@ -241,7 +244,7 @@ func (h *Helm) InstallChart(name, repo, chart string) {
 	}
 
 	if h.clusteradmFlags.DryRun {
-		fmt.Println(release.Manifest)
+		fmt.Fprintln(h.streams.Out, release.Manifest)
 	}
 }
 

--- a/test/e2e/clusteradm/addon_lifecycle_test.go
+++ b/test/e2e/clusteradm/addon_lifecycle_test.go
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe("test clusteradm with addon create", ginkgo.Label("addon
 				"create",
 				"test-nginx",
 				"-f",
-				"test/e2e/clusteradm/scenario/addon/nginx.yaml",
+				"scenario/addon/nginx.yaml",
 				"--hub-registration",
 				"--cluster-role-bind",
 				"configmap-reader",

--- a/test/e2e/clusteradm/joinhubscenario_klusterletvaluesfile_test.go
+++ b/test/e2e/clusteradm/joinhubscenario_klusterletvaluesfile_test.go
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe("test clusteradm join with klusterlet values file", gink
 
 			ginkgo.By("managedcluster1 join hub with klusterlet values file")
 
-			klusterletValuesFile, err := filepath.Abs(filepath.Join("test", "e2e", "clusteradm", "testdata", "klusterlet-values-join.yaml"))
+			klusterletValuesFile, err := filepath.Abs(filepath.Join("testdata", "klusterlet-values-join.yaml"))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get absolute path for klusterlet values file")
 
 			err = e2e.Clusteradm().Join(

--- a/test/e2e/clusteradm/joinhubscenario_skip_approve_test.go
+++ b/test/e2e/clusteradm/joinhubscenario_skip_approve_test.go
@@ -34,6 +34,7 @@ var _ = ginkgo.Describe("test clusteradm with manual bootstrap token", ginkgo.La
 			err = clusterAdm.Init(
 				"--timeout", "400",
 				"--context", e2e.Cluster().Hub().Context(),
+				"--wait",
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "clusteradm init error")
 			ginkgo.By("init files with manual bootstrap token")

--- a/test/e2e/clusteradm/upgrade_klusterletvaluesfile_test.go
+++ b/test/e2e/clusteradm/upgrade_klusterletvaluesfile_test.go
@@ -71,7 +71,7 @@ var _ = ginkgo.Describe("test clusteradm upgrade klusterlet with klusterlet valu
 
 			ginkgo.By("upgrade klusterlet with advanced klusterlet file")
 
-			klusterletValuesFile, err := filepath.Abs(filepath.Join("test", "e2e", "clusteradm", "testdata", "klusterlet-values-upgrade.yaml"))
+			klusterletValuesFile, err := filepath.Abs(filepath.Join("testdata", "klusterlet-values-upgrade.yaml"))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get absolute path for klusterlet values file")
 
 			err = e2e.Clusteradm().Upgrade(

--- a/test/e2e/clusteradm/version_test.go
+++ b/test/e2e/clusteradm/version_test.go
@@ -9,7 +9,7 @@ import (
 var _ = ginkgo.Describe("test clusteradm version", ginkgo.Label("version"), func() {
 	var err error
 
-	ginkgo.It("write your tests here", func() {
+	ginkgo.It("check clusteradm version", func() {
 		err = e2e.Clusteradm().Version()
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "clusteradm version check error")
 	})

--- a/test/e2e/e2e-test.mk
+++ b/test/e2e/e2e-test.mk
@@ -17,8 +17,8 @@ clean-e2e:
 # start clusters and set context variables
 start-cluster: 
 	kind create cluster --name ${MANAGED_CLUSTER1_NAME}
-	kind create cluster --name ${HUB_NAME} --image kindest/node:v1.24.0
-.PHONY: start-cluster 
+	kind create cluster --name ${HUB_NAME} --image kindest/node:v1.35.8@sha256:07b2536e30b803ed61d1677a79df6115f798ce64c80f9e22f6ed45afd09323c0
+.PHONY: start-cluster
 
 test-e2e: clean-e2e envtest-setup ensure-ginkgo start-cluster deps install
 	go test -c ./test/e2e/clusteradm

--- a/test/e2e/e2e-test.mk
+++ b/test/e2e/e2e-test.mk
@@ -20,12 +20,9 @@ start-cluster:
 	kind create cluster --name ${HUB_NAME} --image kindest/node:v1.35.8@sha256:07b2536e30b803ed61d1677a79df6115f798ce64c80f9e22f6ed45afd09323c0
 .PHONY: start-cluster
 
-test-e2e: clean-e2e envtest-setup ensure-ginkgo start-cluster deps install
-	go test -c ./test/e2e/clusteradm
-	./clusteradm.test -test.v -ginkgo.v -test.timeout=3600s \
-	$(if $(GINKGO_LABEL_FILTER),-ginkgo.label-filter="$(GINKGO_LABEL_FILTER)") -bundle-version=$(BUNDLE_VERSION)
+test-e2e: clean-e2e ensure-ginkgo start-cluster deps install test-e2e-only
 .PHONY: test-e2e
 
-test-only:
-	$(GINKGO) -v --timeout 3600s ./test/e2e/clusteradm
-.PHONY: test-only
+test-e2e-only:
+	$(GINKGO) -v --timeout 3600s $(if $(GINKGO_LABEL_FILTER),--label-filter="$(GINKGO_LABEL_FILTER)") ./test/e2e/clusteradm -- --bundle-version=$(BUNDLE_VERSION)
+.PHONY: test-e2e-only

--- a/test/e2e/util/helper.go
+++ b/test/e2e/util/helper.go
@@ -33,15 +33,17 @@ func WaitNamespaceDeleted(restcfg *rest.Config, namespace string) error {
 		return err
 	}
 
-	return wait.PollUntilContextCancel(context.TODO(), 1*time.Second, true, func(ctx context.Context) (bool, error) {
-		ns, err := clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	return wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 300*time.Second, true, func(ctx context.Context) (bool, error) {
+		_, err := clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return true, nil
 		}
 		if err != nil {
-			return false, err
+			if ctx.Err() != nil {
+				return false, err
+			}
+			return false, nil
 		}
-		fmt.Printf("namespace %s still exists %v\n", ns.Name, ns.Status)
 		return false, nil
 	})
 }
@@ -63,22 +65,36 @@ func WaitClustersDeleted(restcfg *rest.Config) error {
 		return err
 	}
 
-	gomega.Eventually(func() error {
-		clusterList, err := clientset.ClusterV1().ManagedClusters().List(context.TODO(), metav1.ListOptions{})
-		if errors.IsNotFound(err) || len(clusterList.Items) == 0 {
-			return nil
-		}
+	namesToFinalizers := map[string][]string{}
+
+	err = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 300*time.Second, true, func(ctx context.Context) (bool, error) {
+		clusterList, err := clientset.ClusterV1().ManagedClusters().List(ctx, metav1.ListOptions{})
 		if err != nil {
-			return err
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, nil
 		}
+		if len(clusterList.Items) == 0 {
+			return true, nil
+		}
+
+		namesToFinalizers = map[string][]string{}
+
 		for _, mcl := range clusterList.Items {
-			err = clientset.ClusterV1().ManagedClusters().Delete(context.TODO(), mcl.Name, metav1.DeleteOptions{})
-			if err != nil {
-				return err
+			namesToFinalizers[mcl.Name] = mcl.Finalizers
+			if mcl.DeletionTimestamp == nil {
+				if err := clientset.ClusterV1().ManagedClusters().Delete(ctx, mcl.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+					return false, err
+				}
 			}
 		}
-		return fmt.Errorf("not all clusters are deleted")
-	}, time.Second*300, time.Second*2).Should(gomega.Succeed())
+		return false, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("not all clusters are deleted: %w; cluster list with their finalizers: %+v", err, namesToFinalizers)
+	}
 
 	return nil
 }

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -89,14 +89,13 @@ func initE2E(version string) (*TestE2eConfig, error) {
 		fmt.Println("cleaning hub...")
 
 		fmt.Println("deleting all clusters on the hub...")
-		// delete all clusters
-		err = WaitClustersDeleted(e2eConf.Cluster().Hub().KubeConfig())
+		err := WaitClustersDeleted(e2eConf.Cluster().Hub().KubeConfig())
 		if err != nil {
 			return err
 		}
 
 		fmt.Println("unjoin managedCluster on the spoke cluster...")
-		err := e2eConf.Clusteradm().Unjoin(
+		err = e2eConf.Clusteradm().Unjoin(
 			"--context", e2eConf.Cluster().ManagedCluster1().Context(),
 			"--cluster-name", e2eConf.Cluster().ManagedCluster1().Name(),
 			"--purge-operator=false",

--- a/test/integration-test.mk
+++ b/test/integration-test.mk
@@ -2,6 +2,17 @@
 
 export KUBEBUILDER_ASSETS ?=$(LOCAL_BIN)/kubebuilder/bin
 export GINKGO ?=$(LOCAL_BIN)/ginkgo
+
+# ref: https://book.kubebuilder.io/reference/envtest.html?highlight=setup-envtest#installation
+# Parse the controller-runtime version from go.mod and parse to its release-X.Y git branch
+ENVTEST_VERSION ?= $(shell go list -mod=readonly -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime 2>/dev/null | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
+# Parse the Kubernetes API version from go.mod (which is v0.Y.Z) and convert to the corresponding v1.Y.Z format
+ENVTEST_K8S_VERSION := $(shell go list -mod=readonly -m -f "{{ .Version }}" k8s.io/api 2>/dev/null | awk -F'[v.]' '{printf "1.%d", $$3}')
+ENVTEST := $(LOCAL_BIN)/setup-envtest
+
+envtest-setup:
+	# Installing setup-envtest using the release-X.Y branch from the version specified in go.mod
+	GOBIN=$(LOCAL_BIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 .PHONY: envtest-setup
 
 ensure-ginkgo:
@@ -18,5 +29,5 @@ clean-integration-test:
 clean: clean-integration-test
 
 test-integration: envtest-setup ensure-ginkgo
-	$(GINKGO) -v ./pkg/cmd/addon/enable  ./pkg/cmd/addon/disable  ./pkg/cmd/install/hubaddon 
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) -v ./pkg/cmd/addon/enable  ./pkg/cmd/addon/disable  ./pkg/cmd/install/hubaddon
 .PHONY: test-integration

--- a/test/integration-test.mk
+++ b/test/integration-test.mk
@@ -1,20 +1,12 @@
 # Copyright Contributors to the Open Cluster Management project
-TEST_TMP :=/tmp
 
-export KUBEBUILDER_ASSETS ?=$(TEST_TMP)/kubebuilder/bin
-export GINKGO ?=$(TEST_TMP)/ginkgo/ginkgo
-
-ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
-
+export KUBEBUILDER_ASSETS ?=$(LOCAL_BIN)/kubebuilder/bin
+export GINKGO ?=$(LOCAL_BIN)/ginkgo
 .PHONY: envtest-setup
-envtest-setup:
-	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
-	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
-
 
 ensure-ginkgo:
-	$(info Downloading ginkgo into '$(TEST_TMP)/ginkgo')
-	GOBIN=$(TEST_TMP)/ginkgo go install github.com/onsi/ginkgo/v2/ginkgo@$(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print $$2}' go.mod)
+	# Downloading ginkgo into '$(GINKGO)'
+	GOBIN=$(LOCAL_BIN) go install github.com/onsi/ginkgo/v2/ginkgo@$(shell awk '/github.com\/onsi\/ginkgo\/v2/ {print $$2}' go.mod)
 .PHONY: ensure-ginkgo
 
 clean-integration-test:


### PR DESCRIPTION
- chore: use `go.mod` for workflow Go version
- chore: use local bin rather than `/tmp` for CLIs
- chore: use `setup-envtest` CLI for envtest
- chore: bump Kind cluster K8s version
- chore: simplify E2E command
- chore: pass streams to Helm client
- chore: update flows for flaky spoke cluster deletion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved join and addon lifecycle cleanup to reduce test failures and ensure resources are removed in the correct order.
  - Improved handling of cluster deletion, including stalled resources.
  - Corrected error handling when hub resource discovery fails.
  - Ensured command output is routed consistently during Helm operations.

- **Tests**
  - Updated end-to-end and integration test setup, fixtures, paths, and readiness checks.
  - Go and Kubernetes tool versions now align automatically with project configuration.
  - Improved local test tool setup and environment configuration.

- **Chores**
  - Strengthened CI workflow permissions and action security.
  - Pinned CI actions and end-to-end test infrastructure for more consistent runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->